### PR TITLE
fix(ci): handle missing direct dependencies in version listing

### DIFF
--- a/.github/workflows/build-feature-branches.yml
+++ b/.github/workflows/build-feature-branches.yml
@@ -58,9 +58,9 @@ jobs:
         working-directory: ./astro-website
         run: |
           echo "Dependency versions:"
-          npm list astro --depth=0
-          npm list typescript --depth=0
-          npm list @astrojs/check --depth=0
+          npm list astro --depth=0 || true
+          npm list typescript --depth=0 || true
+          npm list @astrojs/check --depth=0 || true
 
       - name: Run TypeScript check
         working-directory: ./astro-website


### PR DESCRIPTION
## Summary
- Fix false build failures in the "List installed versions" step
- Add `|| true` to npm list commands that may return non-zero for transitive dependencies

## Problem
The `npm list typescript --depth=0` command returns "(empty)" with exit code 1 because TypeScript is a transitive dependency (via @astrojs/check), not a direct dependency. This caused PR #14 to show a failing build even though the actual build/tests pass.

## Solution
Add `|| true` to the informational npm list commands. This step is for logging purposes only, not validation.

## Test plan
- [x] Verify CI passes on this branch
- [ ] Merge PR #14 (security fix) after this is merged

---
Generated with [Claude Code](https://claude.com/claude-code)