### PR TITLE
feat(spec): add SpecKit Project Updater feature specification

### DIFF
--- a/specs/009-speckit-project-updater/plan.md
+++ b/specs/009-speckit-project-updater/plan.md
@@ -1,0 +1,309 @@
+# Implementation Plan: SpecKit Project Updater
+
+**Branch**: `009-speckit-project-updater` | **Date**: 2026-01-21 | **Spec**: [spec.md](spec.md)
+**Git Branch**: `20260121-XXXXXX-feat-speckit-project-updater` (constitutional format)
+**Input**: Feature specification from `/specs/009-speckit-project-updater/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+
+## Summary
+
+Add a SpecKit Project Updater feature to the TUI Extras menu that allows users to:
+1. Track speckit installations across multiple project directories
+2. Compare speckit files against canonical versions in this repo
+3. Preview and apply patches to enforce constitutional branch naming
+4. Manage backups and rollbacks for safety
+
+## Technical Context
+
+**Language/Version**: Go 1.23
+**Primary Dependencies**: Bubbletea v1.2.4, Bubbles v0.20.0, Lipgloss v1.0.0
+**Storage**: `~/.config/ghostty-installer/speckit-projects.json` (JSON config file)
+**Testing**: Manual testing + `go build` validation
+**Target Platform**: Linux (Ubuntu 25.10)
+**Project Type**: Single Go module (TUI application)
+**Performance Goals**: Scan operations <5 seconds per project
+**Constraints**: Must work offline, no network dependencies
+**Scale/Scope**: 13 existing ViewStates, adding 2 new (ViewSpecKitUpdater, ViewSpecKitProjectDetail)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### Pre-Design Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Script Consolidation | ✅ PASS | No new shell scripts - all changes in Go code |
+| II. Branch Preservation | ✅ PASS | Using constitutional branch format `YYYYMMDD-HHMMSS-feat-*` |
+| III. Local-First CI/CD | ✅ PASS | Must run `go build` before commits |
+| IV. Modularity Limits | ✅ PASS | New files ~200-250 lines each, under 300 limit |
+| V. Symlink Single Source | ✅ PASS | Not touching AGENTS.md or symlinks |
+
+### Protected Files Check
+
+| File | Impact | Notes |
+|------|--------|-------|
+| `docs/.nojekyll` | No impact | Not touched |
+| `AGENTS.md` | No impact | Not touched |
+| Symlinks | No impact | Not touched |
+
+### Technology Stack Check
+
+| Requirement | Status | Notes |
+|-------------|--------|-------|
+| Go 1.23+ | ✅ PASS | Using Go 1.23 per go.mod |
+| Bubbletea patterns | ✅ PASS | Following existing Elm architecture |
+| JSON persistence | ✅ PASS | Using encoding/json for config |
+
+**GATE RESULT**: ✅ PASS - Proceeding to design
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/009-speckit-project-updater/
+├── spec.md              # Feature specification
+├── plan.md              # This file (implementation plan)
+└── tasks.md             # Task breakdown (to be created)
+```
+
+### Source Code (new files)
+
+```text
+tui/internal/
+├── ui/
+│   ├── model.go             # MODIFY: Add ViewSpecKitUpdater, ViewSpecKitProjectDetail states
+│   ├── extras.go            # MODIFY: Add menu item for SpecKit Updater
+│   ├── speckitupdater.go    # NEW: Main list view for tracked projects
+│   ├── speckitdetail.go     # NEW: Single project detail with actions
+│   └── styles.go            # MODIFY: Add styles for diff view
+├── speckit/                 # NEW: SpecKit package for core logic
+│   ├── config.go            # Config persistence (JSON load/save)
+│   ├── scanner.go           # File comparison logic
+│   ├── patcher.go           # Backup and patch application
+│   └── types.go             # TrackedProject, FileDifference types
+└── ...
+```
+
+### Integration Points
+
+| Component | File | Change |
+|-----------|------|--------|
+| ViewState enum | `model.go` | Add `ViewSpecKitUpdater`, `ViewSpecKitProjectDetail` |
+| Model fields | `model.go` | Add `speckitUpdater *SpecKitUpdaterModel`, `speckitDetail *SpecKitDetailModel` |
+| Extras menu | `extras.go` | Add "SpecKit Updater" menu item |
+| Navigation | `model.go` | Handle navigation to/from SpecKit views |
+| Messages | `model.go` | Add message types for async operations |
+
+## Architecture
+
+### View Flow
+
+```
+ViewExtras
+    │
+    ├─[Select "SpecKit Updater"]─→ ViewSpecKitUpdater (project list)
+    │                                    │
+    │                                    ├─[Add Project]─→ Text input modal
+    │                                    │
+    │                                    ├─[Select Project]─→ ViewSpecKitProjectDetail
+    │                                    │                          │
+    │                                    │                          ├─[Scan]─→ Compare files
+    │                                    │                          ├─[Preview]─→ Show diff
+    │                                    │                          ├─[Apply]─→ Backup & patch
+    │                                    │                          ├─[Rollback]─→ Restore backup
+    │                                    │                          └─[Remove]─→ Confirm → Remove
+    │                                    │
+    │                                    └─[Update All]─→ ViewBatchPreview
+    │
+    └─[Escape]─→ ViewDashboard
+```
+
+### Package Responsibilities
+
+| Package | Responsibility |
+|---------|----------------|
+| `tui/internal/ui` | TUI views and user interaction |
+| `tui/internal/speckit` | Core business logic (config, scan, patch) |
+| `tui/internal/config` | May extend for speckit config path |
+
+### Data Flow
+
+1. **Config Loading**: On TUI start, load `~/.config/ghostty-installer/speckit-projects.json`
+2. **Project List**: Display tracked projects with cached status
+3. **Scan**: Compare project's `.specify/scripts/bash/` against canonical files
+4. **Preview**: Generate unified diff for changed files
+5. **Patch**: Create backup, apply line-range patches
+6. **Persist**: Save updated config after any changes
+
+### Message Types
+
+```go
+// Async operation messages
+type specKitConfigLoadedMsg struct { config *speckit.ProjectConfig; err error }
+type specKitScanCompleteMsg struct { projectPath string; diffs []speckit.FileDifference; err error }
+type specKitPatchCompleteMsg struct { projectPath string; backupPath string; err error }
+type specKitRollbackCompleteMsg struct { projectPath string; err error }
+```
+
+## Key Components
+
+### SpecKitUpdaterModel (speckitupdater.go)
+
+Main list view showing all tracked projects:
+- List of tracked projects with status icons
+- Actions: Add Project, Update All, Refresh
+- Navigation: Arrow keys, Enter to select, Esc to return
+
+### SpecKitDetailModel (speckitdetail.go)
+
+Single project detail view:
+- Project path and status
+- List of differing files (if scanned)
+- Actions: Scan, Preview, Apply, Rollback, Remove
+- Diff viewer (inline or scrollable)
+
+### speckit.Config (config.go)
+
+Persistence layer:
+- Load/Save JSON config
+- Add/Remove tracked projects
+- Update project status
+
+### speckit.Scanner (scanner.go)
+
+File comparison:
+- Compare `.specify/scripts/bash/*.sh` files
+- Identify differing line ranges
+- Generate unified diff output
+
+### speckit.Patcher (patcher.go)
+
+Backup and patch:
+- Create timestamped backup directory
+- Copy affected files to backup
+- Apply patches (replace line ranges)
+- Restore from backup on failure
+
+## Config File Schema
+
+```json
+{
+  "version": 1,
+  "projects": [
+    {
+      "path": "/home/user/myproject",
+      "lastScanned": "2026-01-21T12:00:00Z",
+      "status": "needs-update",
+      "lastBackup": "/home/user/myproject/.specify/.backup-20260121-120000"
+    }
+  ]
+}
+```
+
+## Canonical Files Reference
+
+The following files from this repo serve as the canonical source for patching:
+
+| File | Purpose |
+|------|---------|
+| `.specify/scripts/bash/common.sh` | Branch validation regex |
+| `.specify/scripts/bash/create-new-feature.sh` | Branch creation with timestamp |
+
+### Patch Targets
+
+**common.sh** - Branch validation (lines ~75-82):
+```bash
+# Current (old pattern only):
+if [[ ! "$branch" =~ ^[0-9]{3}- ]]; then
+
+# Required (add constitutional pattern):
+if [[ ! "$branch" =~ ^[0-9]{3}- ]] && [[ ! "$branch" =~ ^[0-9]{8}-[0-9]{6}- ]]; then
+```
+
+**create-new-feature.sh** - Branch creation (lines ~283-313):
+- Add timestamp generation
+- Change branch name format to `YYYYMMDD-HHMMSS-type-description`
+- Keep spec directory as `NNN-description`
+
+## Post-Design Constitution Check
+
+*Re-evaluated after design completion.*
+
+| Principle | Status | Post-Design Notes |
+|-----------|--------|-------------------|
+| I. Script Consolidation | ✅ PASS | Only Go files created. No new shell scripts. |
+| II. Branch Preservation | ✅ PASS | Using constitutional format `YYYYMMDD-HHMMSS-feat-*` |
+| III. Local-First CI/CD | ✅ PASS | `go build ./cmd/installer` required before each commit |
+| IV. Modularity Limits | ✅ PASS | All new files under 300 lines |
+| V. Symlink Single Source | ✅ PASS | No changes to AGENTS.md, CLAUDE.md, or GEMINI.md |
+
+### Files Summary
+
+| Action | File | Lines (est) |
+|--------|------|-------------|
+| CREATE | `tui/internal/speckit/types.go` | ~50 |
+| CREATE | `tui/internal/speckit/config.go` | ~100 |
+| CREATE | `tui/internal/speckit/scanner.go` | ~150 |
+| CREATE | `tui/internal/speckit/patcher.go` | ~150 |
+| CREATE | `tui/internal/ui/speckitupdater.go` | ~200 |
+| CREATE | `tui/internal/ui/speckitdetail.go` | ~200 |
+| MODIFY | `tui/internal/ui/model.go` | +80 |
+| MODIFY | `tui/internal/ui/extras.go` | +20 |
+| MODIFY | `tui/internal/ui/styles.go` | +30 |
+
+**Total new code**: ~960 lines across 6 new files + ~130 lines in modified files
+
+**GATE RESULT**: ✅ PASS - Ready for task generation
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| New package (speckit) | Separates business logic from UI | Single file would exceed 300-line limit and mix concerns |
+
+## Dependencies
+
+### Internal Dependencies
+
+- `tui/internal/config` - May use for config path utilities
+- `tui/internal/cache` - Pattern reference for status caching
+
+### External Dependencies (existing)
+
+- `encoding/json` - Config persistence
+- `os` - File operations
+- `path/filepath` - Path manipulation
+- `bufio` - Line-by-line file reading
+- `io` - File copying for backup
+
+No new external dependencies required.
+
+## Testing Strategy
+
+1. **Unit Tests**:
+   - `speckit/config_test.go` - Config load/save
+   - `speckit/scanner_test.go` - File comparison
+   - `speckit/patcher_test.go` - Backup/restore
+
+2. **Integration Tests**:
+   - Manual: Add real project, scan, preview, apply, rollback
+
+3. **Build Validation**:
+   - `go build ./cmd/installer` must pass
+   - TUI must launch without errors
+
+## Risk Assessment
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| File corruption during patch | High | Mandatory backup before any modification |
+| Config file corruption | Medium | Schema version + graceful reset |
+| Large number of projects (>50) | Low | Pagination in UI, lazy loading |
+| Permission errors | Medium | Clear error messages, skip unwritable projects |
+
+## Open Questions
+
+None currently - all clarified in spec.md

--- a/specs/009-speckit-project-updater/spec.md
+++ b/specs/009-speckit-project-updater/spec.md
@@ -1,0 +1,258 @@
+# Feature Specification: SpecKit Project Updater
+
+**Feature Branch**: `009-speckit-project-updater`
+**Git Branch**: `20260121-XXXXXX-feat-speckit-project-updater` (constitutional format)
+**Created**: 2026-01-21
+**Status**: Draft
+**Input**: TUI feature to update speckit installations across computer to enforce constitutional branch naming
+
+## Problem Statement
+
+When users install speckit via `uvx specify-ai init` for a new project, it uses GitHub's default speckit template which includes the older branch naming pattern (`NNN-feature-name`). Users of this repository (ghostty-config-files) have adopted a constitutional branch naming policy that mandates the format `YYYYMMDD-HHMMSS-type-description`.
+
+Currently, there is no way to:
+1. Track which projects on the user's computer have speckit installed
+2. Compare those projects' speckit files against the canonical version in this repo
+3. Automatically patch those files to enforce constitutional branch naming
+
+Users must manually update each project's speckit files, which is error-prone and time-consuming.
+
+## Proposed Solution
+
+Add a "SpecKit Project Updater" feature to the TUI Extras menu that:
+1. Maintains a list of project directories where speckit is installed
+2. Scans those directories for `.specify/` folders
+3. Compares speckit script files against the canonical versions in this repo
+4. Shows a preview of proposed changes before patching
+5. Creates timestamped backups before any modifications
+6. Applies patches to enforce constitutional branch naming
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Add Project Directory (Priority: P1)
+
+As a user, I want to add project directories to the SpecKit Updater, so I can track which projects need constitutional branch naming enforcement.
+
+**Why this priority**: Without the ability to add projects, no other functionality works. This is the foundation of the feature.
+
+**Independent Test**: Navigate to SpecKit Project Updater → Add Project → Enter path → Verify project appears in list.
+
+**Acceptance Scenarios**:
+
+1. **Given** user is in SpecKit Project Updater view, **When** they select "Add Project", **Then** they see a text input for directory path
+2. **Given** user enters a valid directory with `.specify/`, **When** they confirm, **Then** the project is added to the list with status "Pending Scan"
+3. **Given** user enters a directory without `.specify/`, **When** they confirm, **Then** they see error "No speckit installation found"
+4. **Given** user enters a non-existent directory, **When** they confirm, **Then** they see error "Directory does not exist"
+
+---
+
+### User Story 2 - Scan Project for Differences (Priority: P1)
+
+As a user, I want to scan a project and see what files differ from the canonical version, so I understand what changes will be made.
+
+**Why this priority**: Users need visibility into changes before applying them. This builds trust and prevents unwanted modifications.
+
+**Independent Test**: Add a project → Select "Scan" → View list of differing files with line numbers.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project is in the list, **When** user selects "Scan", **Then** system compares `.specify/scripts/bash/` files against canonical versions
+2. **Given** scan completes, **When** differences exist, **Then** user sees list of files with specific line ranges that differ
+3. **Given** scan completes, **When** no differences exist, **Then** user sees "Project is up to date"
+4. **Given** scan is in progress, **When** user views the project, **Then** they see a spinner with "Scanning..."
+
+---
+
+### User Story 3 - Preview Changes Before Patching (Priority: P1)
+
+As a user, I want to see exactly what changes will be made to each file before patching, so I can verify the patches are correct.
+
+**Why this priority**: Blind patching could break projects. Users must see changes before applying.
+
+**Independent Test**: Select project with differences → Choose "Preview Changes" → View side-by-side or unified diff.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project has scanned differences, **When** user selects "Preview Changes", **Then** they see ViewDiff screen with file-by-file changes
+2. **Given** preview is shown, **When** user navigates between files, **Then** they can see each file's proposed changes
+3. **Given** preview is shown, **When** user presses Escape, **Then** they return to project detail without changes
+4. **Given** multiple files have changes, **When** user views preview, **Then** they see count "File 1 of N"
+
+---
+
+### User Story 4 - Apply Patches with Backup (Priority: P1)
+
+As a user, I want patches applied with automatic backup, so I can safely update my projects knowing I can rollback.
+
+**Why this priority**: Core functionality - actually applying the changes. Backup is mandatory for safety.
+
+**Independent Test**: Preview changes → Confirm "Apply" → Verify backup created and files patched.
+
+**Acceptance Scenarios**:
+
+1. **Given** user confirms apply, **When** patching starts, **Then** system creates backup at `{project}/.specify/.backup-{YYYYMMDD-HHMMSS}/`
+2. **Given** backup is created, **When** patching proceeds, **Then** system modifies only the specific line ranges identified
+3. **Given** patching completes successfully, **When** user views project, **Then** status shows "Up to date" with backup timestamp
+4. **Given** patching fails, **When** error occurs, **Then** system restores from backup and shows error message
+
+---
+
+### User Story 5 - Remove Project from List (Priority: P2)
+
+As a user, I want to remove projects I no longer want to track, so my list stays manageable.
+
+**Why this priority**: Housekeeping feature, less critical than core functionality.
+
+**Independent Test**: Select project → Choose "Remove" → Verify project no longer in list.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project is in the list, **When** user selects "Remove", **Then** they see confirmation dialog
+2. **Given** confirmation shown, **When** user confirms, **Then** project is removed from tracking list
+3. **Given** project is removed, **When** user views list, **Then** the project no longer appears
+4. **Given** project is removed, **When** the actual `.specify/` still exists, **Then** the files are NOT deleted (only tracking removed)
+
+---
+
+### User Story 6 - Batch Update All Projects (Priority: P2)
+
+As a user, I want to update all tracked projects at once, so I can efficiently enforce constitutional naming across all my work.
+
+**Why this priority**: Convenience feature for users with many projects.
+
+**Independent Test**: With multiple projects showing differences → Select "Update All" → Verify all updated with backups.
+
+**Acceptance Scenarios**:
+
+1. **Given** multiple projects have differences, **When** user selects "Update All", **Then** they see batch preview listing all projects
+2. **Given** batch preview shown, **When** user confirms, **Then** system processes each project sequentially with progress
+3. **Given** batch update in progress, **When** one project fails, **Then** system shows error but continues with remaining projects
+4. **Given** batch update completes, **When** user views list, **Then** each project shows individual success/failure status
+
+---
+
+### User Story 7 - Rollback from Backup (Priority: P2)
+
+As a user, I want to rollback a patched project to its previous state, so I can undo changes if needed.
+
+**Why this priority**: Safety net feature, important but not blocking core use.
+
+**Independent Test**: Select patched project → Choose "Rollback" → Verify files restored from backup.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project has been patched (backup exists), **When** user selects "Rollback", **Then** they see confirmation with backup timestamp
+2. **Given** rollback confirmed, **When** system restores, **Then** files are copied from backup to original locations
+3. **Given** rollback completes, **When** user scans project, **Then** differences reappear (pre-patch state)
+4. **Given** no backup exists, **When** user views project, **Then** "Rollback" option is not shown
+
+---
+
+### Edge Cases
+
+- What happens if canonical files don't exist in this repo? → Error "Canonical speckit files not found in repository"
+- What if project path contains spaces? → System handles paths with spaces correctly
+- What if user lacks write permission to project? → Error "Permission denied: Cannot write to {path}"
+- What if `.specify/.backup-*` already exists? → Create new backup with current timestamp (no overwrite)
+- What if project is a git repo with uncommitted changes? → Warning "Project has uncommitted git changes" (proceed anyway)
+- What happens if disk is full during backup? → Error "Insufficient disk space for backup", abort patch
+- What if config file is corrupted? → Reset to empty list, log warning
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: TUI MUST provide menu item in Extras view for "SpecKit Project Updater"
+- **FR-002**: System MUST persist project list to `~/.config/ghostty-installer/speckit-projects.json`
+- **FR-003**: System MUST detect speckit presence via existence of `.specify/` directory
+- **FR-004**: System MUST compare files against canonical versions in this repo's `.specify/scripts/bash/`
+- **FR-005**: System MUST create timestamped backup before patching (`{project}/.specify/.backup-{YYYYMMDD-HHMMSS}/`)
+- **FR-006**: System MUST show preview of changes before applying (no silent patching)
+- **FR-007**: System MUST support adding, removing, and listing tracked projects
+- **FR-008**: System MUST support scanning individual projects or all projects
+- **FR-009**: System MUST support rollback to most recent backup
+- **FR-010**: System MUST handle errors gracefully and restore from backup on patch failure
+
+### Key Files to Patch
+
+The following canonical files enforce constitutional branch naming and should be patched in target projects:
+
+| File | Lines | Purpose |
+|------|-------|---------|
+| `.specify/scripts/bash/common.sh` | 75-82 | Branch validation regex - add support for constitutional `YYYYMMDD-HHMMSS-type-*` pattern |
+| `.specify/scripts/bash/create-new-feature.sh` | 280-313 | Timestamp generation and branch creation - use constitutional format |
+
+### Patch Details
+
+**common.sh lines 75-82** (branch validation):
+- Current: Only accepts `^[0-9]{3}-` pattern
+- Required: Also accept `^[0-9]{8}-[0-9]{6}-` (constitutional timestamp) pattern
+
+**create-new-feature.sh lines 280-313** (branch creation):
+- Current: Creates branches as `NNN-feature-name`
+- Required: Creates branches as `YYYYMMDD-HHMMSS-type-feature-name`
+- Spec directories remain as `NNN-feature-name` for organizational purposes
+
+### Key Entities
+
+- **TrackedProject**: A project directory with speckit installation being monitored
+  - `path`: Absolute path to project root
+  - `lastScanned`: Timestamp of last scan (ISO 8601)
+  - `status`: "pending" | "up-to-date" | "needs-update" | "error"
+  - `differences`: Array of file differences found
+  - `lastBackup`: Path to most recent backup, if exists
+
+- **FileDifference**: A detected difference in a speckit file
+  - `file`: Relative path within `.specify/`
+  - `lineStart`: First differing line number
+  - `lineEnd`: Last differing line number
+  - `canonicalContent`: Content from this repo
+  - `projectContent`: Content from target project
+
+- **ProjectConfig**: Persisted configuration
+  - `projects`: Array of TrackedProject paths
+  - `version`: Config schema version
+
+## Non-Functional Requirements
+
+- **NFR-001**: Scanning should complete in <5 seconds per project
+- **NFR-002**: Config file must be human-readable JSON
+- **NFR-003**: Backup must preserve file permissions
+- **NFR-004**: System must work offline (no network required)
+- **NFR-005**: Memory usage should not exceed 50MB even with 100 tracked projects
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can add at least 20 projects to tracking list
+- **SC-002**: Scan correctly identifies 100% of differing lines in speckit files
+- **SC-003**: Patches apply successfully without corrupting files
+- **SC-004**: Rollback restores files to exact pre-patch state (byte-identical)
+- **SC-005**: TUI navigates through all SpecKit Updater views without crashes
+- **SC-006**: Config persists between TUI sessions
+- **SC-007**: Batch update processes all projects even if some fail
+
+## Clarifications
+
+### Session 2026-01-21
+
+- Q: Should this feature modify files outside `.specify/scripts/bash/`? → A: No, only bash scripts that affect branch naming
+- Q: Should we track speckit version? → A: No, focus on specific files that need constitutional naming
+- Q: What if user has customized speckit files? → A: Show diff and let user decide; only patch the specific constitutional lines
+
+## Assumptions
+
+- Canonical speckit files in this repo are the authoritative source for constitutional naming
+- Users want consistent branch naming across all their speckit projects
+- The TUI Extras menu pattern is the correct integration point
+- JSON is acceptable format for config persistence
+- Users have write access to their project directories
+
+## Out of Scope
+
+- Automatic detection of speckit projects (user must manually add)
+- Integration with speckit upstream (this is local enforcement only)
+- Patching non-bash speckit files (templates, etc.)
+- Git commit/push of patched files (user handles version control)
+- Network sync of project list between machines

--- a/specs/009-speckit-project-updater/tasks.md
+++ b/specs/009-speckit-project-updater/tasks.md
@@ -1,0 +1,393 @@
+# Tasks: SpecKit Project Updater
+
+**Input**: Design documents from `/specs/009-speckit-project-updater/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories)
+
+**Tests**: Unit tests for speckit package (config, scanner, patcher) recommended.
+
+**Organization**: Tasks are grouped by component/phase to enable incremental delivery and clear dependencies.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, etc.)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **TUI Application**: `tui/internal/ui/` for UI components
+- **SpecKit Package**: `tui/internal/speckit/` for core logic
+- **Config**: `tui/internal/config/` for config path utilities
+
+---
+
+## Phase 1: Setup & Package Structure
+
+**Purpose**: Create package structure and add ViewState definitions
+
+- [ ] T001 Verify current build compiles with `cd tui && go build ./cmd/installer`
+- [ ] T002 Create directory `tui/internal/speckit/`
+- [ ] T003 Add ViewSpecKitUpdater constant to View enum in tui/internal/ui/model.go
+- [ ] T004 [P] Add ViewSpecKitProjectDetail constant to View enum in tui/internal/ui/model.go
+- [ ] T005 [P] Add speckitUpdater field (*SpecKitUpdaterModel) to Model struct in tui/internal/ui/model.go
+- [ ] T006 [P] Add speckitDetail field (*SpecKitDetailModel) to Model struct in tui/internal/ui/model.go
+
+**Checkpoint**: Package structure ready, ViewStates defined
+
+---
+
+## Phase 2: Core Types & Config Persistence
+
+**Purpose**: Define data structures and implement config persistence (enables all user stories)
+
+**⚠️ CRITICAL**: User Stories 1-7 depend on this phase for config loading/saving
+
+### Types (tui/internal/speckit/types.go)
+
+- [ ] T007 Create tui/internal/speckit/types.go with package declaration
+- [ ] T008 Define ProjectStatus type (string enum: pending, up-to-date, needs-update, error)
+- [ ] T009 Define FileDifference struct (File, LineStart, LineEnd, CanonicalContent, ProjectContent)
+- [ ] T010 Define TrackedProject struct (Path, LastScanned, Status, Differences, LastBackup)
+- [ ] T011 Define ProjectConfig struct (Version, Projects)
+
+### Config Persistence (tui/internal/speckit/config.go)
+
+- [ ] T012 Create tui/internal/speckit/config.go with package declaration
+- [ ] T013 Implement getConfigPath() returning ~/.config/ghostty-installer/speckit-projects.json
+- [ ] T014 Implement LoadConfig() (JSON load, returns *ProjectConfig, creates empty if missing)
+- [ ] T015 Implement SaveConfig(*ProjectConfig) (JSON save with indentation)
+- [ ] T016 Implement AddProject(path string) (validates .specify/ exists, adds to config)
+- [ ] T017 Implement RemoveProject(path string) (removes from config by path)
+- [ ] T018 Implement UpdateProjectStatus(path, status, diffs, backup) (updates existing project)
+
+**Checkpoint**: Config can be loaded, saved, and modified
+
+---
+
+## Phase 3: Scanner Implementation
+
+**Purpose**: File comparison logic (enables User Stories 2, 3)
+
+### Scanner (tui/internal/speckit/scanner.go)
+
+- [ ] T019 Create tui/internal/speckit/scanner.go with package declaration
+- [ ] T020 Implement getCanonicalFilePaths(repoRoot string) returning list of canonical bash scripts
+- [ ] T021 Implement readFileLines(path string) returning []string and error
+- [ ] T022 Implement compareFiles(canonicalPath, projectPath string) returning []FileDifference
+- [ ] T023 Implement ScanProject(projectPath, repoRoot string) returning ([]FileDifference, error)
+- [ ] T024 Implement generateUnifiedDiff(canonical, project []string, filename string) returning string
+- [ ] T025 Verify scanner compiles with `cd tui && go build ./cmd/installer`
+
+**Checkpoint**: Can scan a project and identify differing lines
+
+---
+
+## Phase 4: Patcher Implementation
+
+**Purpose**: Backup and patch logic (enables User Stories 4, 7)
+
+### Patcher (tui/internal/speckit/patcher.go)
+
+- [ ] T026 Create tui/internal/speckit/patcher.go with package declaration
+- [ ] T027 Implement createBackupDir(projectPath string) returning backup path with timestamp
+- [ ] T028 Implement copyFile(src, dst string) for backup operations
+- [ ] T029 Implement CreateBackup(projectPath string, files []string) returning backupPath, error
+- [ ] T030 Implement ApplyPatch(projectPath, repoRoot string, diffs []FileDifference) returning error
+- [ ] T031 Implement RestoreFromBackup(projectPath, backupPath string) returning error
+- [ ] T032 Implement GetLatestBackup(projectPath string) returning backupPath, error
+- [ ] T033 Verify patcher compiles with `cd tui && go build ./cmd/installer`
+
+**Checkpoint**: Can backup, patch, and rollback files
+
+---
+
+## Phase 5: User Story 1 - Add Project Directory (Priority: P1) 🎯 MVP
+
+**Goal**: Users can add project directories to the SpecKit Updater
+
+**Independent Test**: Navigate to SpecKit Updater → Add Project → Enter path → Verify project appears in list.
+
+### SpecKitUpdaterModel (tui/internal/ui/speckitupdater.go)
+
+- [ ] T034 [US1] Create tui/internal/ui/speckitupdater.go with package declaration
+- [ ] T035 [US1] Define SpecKitUpdaterModel struct (projects, cursor, loading, state, config, repoRoot)
+- [ ] T036 [US1] Define menu items (Add Project, Update All, Refresh, Back)
+- [ ] T037 [US1] Implement NewSpecKitUpdaterModel constructor
+- [ ] T038 [US1] Implement Init() returning config load command
+- [ ] T039 [US1] Implement Update() with keyboard navigation (arrow keys, enter, esc)
+- [ ] T040 [US1] Implement handleAddProject() showing text input modal
+- [ ] T041 [US1] Implement handleProjectSelect() navigating to ViewSpecKitProjectDetail
+- [ ] T042 [US1] Implement View() rendering project list with status icons
+- [ ] T043 [US1] Add styles for speckit views in tui/internal/ui/styles.go
+
+### Model Integration
+
+- [ ] T044 [US1] Add ViewSpecKitUpdater case to View() switch in tui/internal/ui/model.go
+- [ ] T045 [US1] Add ViewSpecKitUpdater handling in Update() for key messages in tui/internal/ui/model.go
+- [ ] T046 [US1] Add specKitConfigLoadedMsg handler in Update() in tui/internal/ui/model.go
+- [ ] T047 [US1] Add "SpecKit Updater" menu item to ExtrasModel in tui/internal/ui/extras.go
+- [ ] T048 [US1] Handle navigation from Extras to ViewSpecKitUpdater in tui/internal/ui/model.go
+
+### Verification
+
+- [ ] T049 [US1] Verify add project with valid path works by running TUI manually
+- [ ] T050 [US1] Verify add project with invalid path shows error
+- [ ] T051 [US1] Verify project list persists after TUI restart
+
+**Checkpoint**: User Story 1 complete - can add and list projects
+
+---
+
+## Phase 6: User Story 2 - Scan Project for Differences (Priority: P1) 🎯 MVP
+
+**Goal**: Users can scan projects and see differing files
+
+**Independent Test**: Add a project → Select "Scan" → View list of differing files.
+
+### SpecKitDetailModel (tui/internal/ui/speckitdetail.go)
+
+- [ ] T052 [US2] Create tui/internal/ui/speckitdetail.go with package declaration
+- [ ] T053 [US2] Define SpecKitDetailModel struct (project, scanning, diffs, cursor, repoRoot)
+- [ ] T054 [US2] Define menu items (Scan, Preview, Apply, Rollback, Remove, Back)
+- [ ] T055 [US2] Implement NewSpecKitDetailModel constructor
+- [ ] T056 [US2] Implement Init() returning nil command
+- [ ] T057 [US2] Implement Update() with keyboard navigation
+- [ ] T058 [US2] Implement handleScan() triggering async scan
+- [ ] T059 [US2] Implement View() showing project info and diff summary
+- [ ] T060 [US2] Implement scanning spinner during async operation
+
+### Model Integration
+
+- [ ] T061 [US2] Add ViewSpecKitProjectDetail case to View() switch in tui/internal/ui/model.go
+- [ ] T062 [US2] Add ViewSpecKitProjectDetail handling in Update() in tui/internal/ui/model.go
+- [ ] T063 [US2] Add specKitScanCompleteMsg handler in Update() in tui/internal/ui/model.go
+- [ ] T064 [US2] Handle navigation from SpecKitUpdater to ViewSpecKitProjectDetail
+
+### Verification
+
+- [ ] T065 [US2] Verify scan shows correct file differences by running TUI manually
+- [ ] T066 [US2] Verify scan shows "up to date" when no differences
+- [ ] T067 [US2] Verify scanning spinner displays during operation
+
+**Checkpoint**: User Story 2 complete - can scan and see differences
+
+---
+
+## Phase 7: User Story 3 - Preview Changes (Priority: P1) 🎯 MVP
+
+**Goal**: Users can preview exact changes before patching
+
+**Independent Test**: Select project with differences → Choose "Preview" → View diff output.
+
+### Preview Implementation
+
+- [ ] T068 [US3] Add previewMode boolean to SpecKitDetailModel in tui/internal/ui/speckitdetail.go
+- [ ] T069 [US3] Add diffOutput string to SpecKitDetailModel for storing unified diff
+- [ ] T070 [US3] Implement handlePreview() generating unified diff from scanner
+- [ ] T071 [US3] Implement renderDiffView() showing file-by-file changes
+- [ ] T072 [US3] Add file navigation (next/prev file) when multiple files
+- [ ] T073 [US3] Implement viewport scrolling for long diffs
+
+### Verification
+
+- [ ] T074 [US3] Verify preview shows unified diff format by running TUI manually
+- [ ] T075 [US3] Verify ESC returns to detail view without changes
+- [ ] T076 [US3] Verify file navigation works with multiple differing files
+
+**Checkpoint**: User Story 3 complete - can preview changes
+
+---
+
+## Phase 8: User Story 4 - Apply Patches with Backup (Priority: P1) 🎯 MVP
+
+**Goal**: Users can apply patches with automatic backup
+
+**Independent Test**: Preview changes → Confirm "Apply" → Verify backup and patched files.
+
+### Apply Implementation
+
+- [ ] T077 [US4] Implement handleApply() in SpecKitDetailModel triggering confirmation
+- [ ] T078 [US4] Show ViewConfirm dialog before patching
+- [ ] T079 [US4] On confirm, call patcher.CreateBackup then patcher.ApplyPatch
+- [ ] T080 [US4] Add specKitPatchCompleteMsg handler in model.go
+- [ ] T081 [US4] Update project status to "up-to-date" after successful patch
+- [ ] T082 [US4] Display backup path after successful patch
+- [ ] T083 [US4] Handle patch failure with automatic restore from backup
+
+### Verification
+
+- [ ] T084 [US4] Verify backup created at correct path by running TUI manually
+- [ ] T085 [US4] Verify files patched correctly (line ranges match)
+- [ ] T086 [US4] Verify status updates to "up to date" after patch
+- [ ] T087 [US4] Verify patch failure triggers rollback
+
+**Checkpoint**: User Story 4 complete - can apply patches with backup
+
+---
+
+## Phase 9: User Story 5 - Remove Project (Priority: P2)
+
+**Goal**: Users can remove projects from tracking list
+
+**Independent Test**: Select project → Choose "Remove" → Verify removal.
+
+### Implementation
+
+- [ ] T088 [US5] Implement handleRemove() showing confirmation dialog
+- [ ] T089 [US5] On confirm, call config.RemoveProject and save
+- [ ] T090 [US5] Return to ViewSpecKitUpdater after removal
+- [ ] T091 [US5] Verify project removed but .specify/ still exists on disk
+
+**Checkpoint**: User Story 5 complete - can remove projects
+
+---
+
+## Phase 10: User Story 6 - Batch Update All (Priority: P2)
+
+**Goal**: Users can update all projects at once
+
+**Independent Test**: With multiple projects needing updates → Select "Update All" → Verify all updated.
+
+### Implementation
+
+- [ ] T092 [US6] Implement getProjectsNeedingUpdates() in SpecKitUpdaterModel
+- [ ] T093 [US6] Create BatchPreviewModel with projects list when "Update All" selected
+- [ ] T094 [US6] Implement batch processing loop in handleBatchConfirm()
+- [ ] T095 [US6] Add progress tracking (current/total projects)
+- [ ] T096 [US6] Continue processing even if one project fails
+- [ ] T097 [US6] Show summary of success/failure counts after batch
+
+### Verification
+
+- [ ] T098 [US6] Verify batch preview shows all projects needing updates
+- [ ] T099 [US6] Verify batch processes all projects sequentially
+- [ ] T100 [US6] Verify failure in one project doesn't stop others
+
+**Checkpoint**: User Story 6 complete - batch update works
+
+---
+
+## Phase 11: User Story 7 - Rollback from Backup (Priority: P2)
+
+**Goal**: Users can rollback to previous state
+
+**Independent Test**: After patching → Select "Rollback" → Verify files restored.
+
+### Implementation
+
+- [ ] T101 [US7] Show "Rollback" action only when lastBackup exists
+- [ ] T102 [US7] Implement handleRollback() showing confirmation with backup timestamp
+- [ ] T103 [US7] On confirm, call patcher.RestoreFromBackup
+- [ ] T104 [US7] Add specKitRollbackCompleteMsg handler in model.go
+- [ ] T105 [US7] Update project status and clear lastBackup after rollback
+- [ ] T106 [US7] Trigger re-scan after rollback to show restored differences
+
+### Verification
+
+- [ ] T107 [US7] Verify rollback restores exact pre-patch state by running TUI manually
+- [ ] T108 [US7] Verify re-scan shows differences after rollback
+- [ ] T109 [US7] Verify "Rollback" hidden when no backup exists
+
+**Checkpoint**: User Story 7 complete - can rollback from backup
+
+---
+
+## Phase 12: Polish & Edge Cases
+
+**Purpose**: Handle edge cases and cleanup
+
+- [ ] T110 Handle permission errors with clear error messages
+- [ ] T111 Handle paths with spaces correctly
+- [ ] T112 Handle corrupted config file (reset to empty)
+- [ ] T113 Add loading states for async operations
+- [ ] T114 [P] Run `cd tui && go build ./cmd/installer` for final verification
+- [ ] T115 [P] Test with real speckit project outside this repo
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+```
+Phase 1: Setup
+    │
+    ▼
+Phase 2: Core Types & Config ──► ALL subsequent phases depend on this
+    │
+    ├─────────────┬─────────────┐
+    ▼             ▼             ▼
+Phase 3:      Phase 4:      Phase 5: US1 (Add Project)
+Scanner       Patcher           │
+    │             │             ▼
+    │             │         Phase 6: US2 (Scan)
+    │             │             │
+    └─────────────┴─────────────┤
+                                ▼
+                          Phase 7: US3 (Preview)
+                                │
+                                ▼
+                          Phase 8: US4 (Apply)
+                                │
+                                ├─────────────────────────┐
+                                ▼                         ▼
+                          Phase 9: US5 (Remove)    Phase 10: US6 (Batch)
+                                                          │
+                                                          ▼
+                                                   Phase 11: US7 (Rollback)
+                                                          │
+                                                          ▼
+                                                   Phase 12: Polish
+```
+
+### MVP Delivery Path
+
+**MVP = Phases 1-8 (User Stories 1-4)**
+
+1. Setup (Phase 1) - 15 min
+2. Core Types & Config (Phase 2) - 30 min
+3. Scanner (Phase 3) - 45 min
+4. Patcher (Phase 4) - 45 min
+5. US1: Add Project (Phase 5) - 1 hour
+6. US2: Scan (Phase 6) - 45 min
+7. US3: Preview (Phase 7) - 45 min
+8. US4: Apply (Phase 8) - 45 min
+
+**MVP Total: ~5.5 hours**
+
+### Post-MVP
+
+9. US5: Remove (Phase 9) - 30 min
+10. US6: Batch (Phase 10) - 1 hour
+11. US7: Rollback (Phase 11) - 45 min
+12. Polish (Phase 12) - 30 min
+
+**Total: ~8 hours**
+
+---
+
+## Parallel Opportunities
+
+### After Phase 2:
+- Phase 3 (Scanner) and Phase 4 (Patcher) can run in parallel
+- Both are independent and don't share files
+
+### After Phase 8:
+- Phase 9 (US5) and Phase 10 (US6) can run in parallel
+- US5 is simple removal, US6 is batch - different code paths
+
+### Within Phases:
+- Tasks marked [P] can run in parallel
+- Sequential tasks depend on prior completion
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story
+- Commit after each phase or logical checkpoint
+- Test each user story independently before moving on
+- All file paths relative to repository root
+- MVP delivers core value (add, scan, preview, apply)
+- P2 stories (remove, batch, rollback) are enhancements


### PR DESCRIPTION
## Summary
- Add feature specification for SpecKit Project Updater (specs/009-speckit-project-updater/)
- Includes spec.md, plan.md, and tasks.md with 115 tasks across 12 phases
- Created 115 GitHub issues (#115-#229) labeled `speckit-project-updater`

## Feature Overview
TUI feature to update speckit installations across the user's computer to enforce constitutional branch naming (`YYYYMMDD-HHMMSS-type-description` format).

### User Stories (7 total)
- **US1**: Add Project Directory (P1)
- **US2**: Scan Project for Differences (P1)
- **US3**: Preview Changes (P1)
- **US4**: Apply Patches with Backup (P1)
- **US5**: Remove Project (P2)
- **US6**: Batch Update All (P2)
- **US7**: Rollback from Backup (P2)

## Test plan
- [ ] Spec files reviewed for completeness
- [ ] All 115 tasks mapped to GitHub issues
- [ ] Plan dependencies validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)