### PR TITLE
chore: ignore .envrc.local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,7 @@ pnpm-lock.yaml
 .env.development.local
 .env.test.local
 .env.production.local
+.envrc.local
 
 # MCP Secrets (API keys - NEVER commit)
 .mcp-secrets


### PR DESCRIPTION
Adds .envrc.local to .gitignore. Prevents accidental commit of the local PAT override file.