### PR TITLE
fix(tmux): enable set-clipboard for system clipboard via OSC 52

### DIFF
--- a/configs/tmux/tmux.conf
+++ b/configs/tmux/tmux.conf
@@ -16,6 +16,7 @@ set -ag terminal-overrides ",ghostty:RGB"
 
 # Mouse support (click to focus pane, scroll)
 set -g mouse on
+set -g set-clipboard on
 
 # No escape key delay (important for Claude Code / vim)
 set -s escape-time 0


### PR DESCRIPTION
## Summary
- Adds `set -g set-clipboard on` to `configs/tmux/tmux.conf`
- Fixes right-click copy not working: tmux's `mouse on` captures all mouse events; with `set-clipboard on`, tmux forwards clipboard ops via OSC 52 which Ghostty supports natively
- Selections and right-click copy now sync to the system clipboard

## Test plan
- [ ] Deploy config: run `scripts/install.sh` and reload tmux (`tmux source ~/.config/tmux/tmux.conf`)
- [ ] Select text in tmux — should copy to system clipboard automatically (`copy-on-select = true` in Ghostty + OSC 52)
- [ ] Right-click → paste in another app confirms clipboard is populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)