### PR TITLE
docs: align documentation and fix config gaps (Opus review)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,13 +5,16 @@ This is a minimal Ghostty terminal config repo. Keep it simple.
 ## What this repo contains
 
 - `configs/ghostty/config` — single Ghostty config file (no modular split)
+- `configs/tmux/tmux.conf` — minimal tmux config (no status bar, Mocha pane borders, mouse on)
 - `scripts/font-picker.fish` — fish font picker function
+- `scripts/dev.fish` — fish function that launches the tmux dev layout (claude left, nu right)
 - `scripts/install.sh` / `uninstall.sh` — deploy/remove scripts
 - `configs/ghostty/catppuccin-mocha.conf` — Mocha palette reference (not deployed)
 
 ## Rules
 
 - Do NOT split the Ghostty config back into modular files.
+- Keep EXACTLY ONE unquoted `font-family =` line in `configs/ghostty/config`. font-picker.fish replaces it via `sed` on `^font-family`; a second line or a quoted value breaks font selection.
 - Do NOT add blur (`background-blur`) — it crashes Ghostty on Linux.
 - Do NOT set `scrollback-limit` above 50000.
 - Do NOT add `config-reload-on-focus-in` — it is not a valid Ghostty 1.3.1 option and fails validation.
@@ -25,6 +28,8 @@ This is a minimal Ghostty terminal config repo. Keep it simple.
 ghostty +validate-config --config-file=configs/ghostty/config   # must exit 0
 shellcheck scripts/install.sh scripts/uninstall.sh
 ```
+
+shellcheck applies only to the `.sh` scripts; the `.fish` functions (`font-picker.fish`, `dev.fish`) are not shellcheck-compatible.
 
 ## User context
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ and pane borders use Catppuccin Mocha surface colors so it looks clean.
 
 ## Installed Nerd Fonts
 
-FiraCode · Hack · JetBrainsMono · JetBrainsMonoNL · MesloLGL · MesloLGM · MesloLGS
+Run `font-picker` to see the live list — it reads `fc-list` directly. On this machine the base families are FiraCode, Hack, JetBrainsMono, JetBrainsMonoNL, MesloLGL, MesloLGLDZ, MesloLGM, MesloLGMDZ, MesloLGS, MesloLGSDZ (each also offered as 'Nerd Font Mono' and 'Nerd Font Propo' variants).
 
 ## Validate config
 

--- a/configs/tmux/tmux.conf
+++ b/configs/tmux/tmux.conf
@@ -16,6 +16,7 @@ set -ag terminal-overrides ",ghostty:RGB"
 
 # Mouse support (click to focus pane, scroll)
 set -g mouse on
+set -g set-clipboard on
 
 # No escape key delay (important for Claude Code / vim)
 set -s escape-time 0

--- a/configs/tmux/tmux.conf
+++ b/configs/tmux/tmux.conf
@@ -16,6 +16,8 @@ set -ag terminal-overrides ",ghostty:RGB"
 
 # Mouse support (click to focus pane, scroll)
 set -g mouse on
+
+# Allow apps to set the system clipboard via OSC 52 (fixes right-click copy)
 set -g set-clipboard on
 
 # No escape key delay (important for Claude Code / vim)

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -20,7 +20,7 @@ if [ -f "$DST_GHOSTTY" ] && grep -q 'managed-by: ghostty-config-files' "$DST_GHO
     else
         echo "Removed $DST_GHOSTTY (no backup to restore)."
     fi
-    rm -f "${DST_GHOSTTY}.bak."* 2>/dev/null || true
+    rm -f "${DST_GHOSTTY}.bak."* 2>/dev/null
 elif [ -L "$DST_GHOSTTY" ] && [[ "$(readlink "$DST_GHOSTTY")" == "$REPO_ROOT"* ]]; then
     rm -f "$DST_GHOSTTY"
     echo "Removed symlink $DST_GHOSTTY"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -20,6 +20,7 @@ if [ -f "$DST_GHOSTTY" ] && grep -q 'managed-by: ghostty-config-files' "$DST_GHO
     else
         echo "Removed $DST_GHOSTTY (no backup to restore)."
     fi
+    rm -f "${DST_GHOSTTY}.bak."* 2>/dev/null || true
 elif [ -L "$DST_GHOSTTY" ] && [[ "$(readlink "$DST_GHOSTTY")" == "$REPO_ROOT"* ]]; then
     rm -f "$DST_GHOSTTY"
     echo "Removed symlink $DST_GHOSTTY"


### PR DESCRIPTION
## Summary

Opus 4.8 multi-agent review of all docs, configs, and scripts. Four fixes applied:

- **AGENTS.md**: added `configs/tmux/tmux.conf` and `scripts/dev.fish` to the "What this repo contains" list (they existed but were omitted); added font-family single-line invariant rule (protects `font-picker.fish`'s `sed` replacement); noted `.fish` files are not shellcheck targets
- **README.md**: replaced stale hardcoded Nerd Font list (7 families, misrepresented picker UI) with a pointer to `font-picker` for the live list
- **configs/tmux/tmux.conf**: added documenting comment for `set-clipboard on` line (OSC 52 clipboard fix)
- **scripts/uninstall.sh**: fixed orphaned `config.bak.*` files — repeated `--force` installs left stale backups that were never cleaned up on uninstall

## Test plan
- [ ] `ghostty +validate-config --config-file=configs/ghostty/config` exits 0
- [ ] `shellcheck scripts/install.sh scripts/uninstall.sh` clean
- [ ] `scripts/install.sh && tmux source ~/.config/tmux/tmux.conf` — right-click copy works in tmux

🤖 Generated with [Claude Code](https://claude.com/claude-code)