### PR TITLE
fix: disable clipboard-trim-trailing-spaces + add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Fixed
+- `clipboard-trim-trailing-spaces` set to `false` — was silently dropping the last character when copied text ended with a space (nushell output, etc.)
+
+## [2026-05-31]
+
+### Fixed
+- tmux: enable `set-clipboard on` for system clipboard pass-through via OSC 52 (#242)
+
+### Added
+- tmux dev layout via `dev.fish` — launches claude (left) + nushell (right) split (#240)
+
+### Changed
+- `.envrc.local` added to `.gitignore` to avoid committing local PAT overrides (#241)
+- Docs aligned across CLAUDE.md / AGENTS.md / GEMINI.md after Opus review (#243)
+
+## [2026-05-28]
+
+### Changed
+- Clean rebuild: single consolidated Ghostty config (no modular includes), font-picker script, install/uninstall scripts (#239)

--- a/configs/ghostty/config
+++ b/configs/ghostty/config
@@ -54,7 +54,7 @@ window-decoration = auto
 gtk-tabs-location = top
 window-new-tab-position = end
 
-clipboard-trim-trailing-spaces = true
+clipboard-trim-trailing-spaces = false
 clipboard-paste-protection = true
 copy-on-select = true
 


### PR DESCRIPTION
## Summary

- `clipboard-trim-trailing-spaces = false` — was silently dropping the last character when copied text ended with a space (nushell output pasted into Claude)
- Added `CHANGELOG.md` covering recent changes

## Test plan

- [ ] Reload config: `Ctrl+Shift+,` or `pkill -SIGUSR2 ghostty`
- [ ] Copy nushell output ending with a space — verify paste is intact
- [ ] Run `./scripts/install.sh` to deploy to `~/.config/ghostty/config`

🤖 Generated with [Claude Code](https://claude.com/claude-code)