### PR TITLE
Update tmux dev workspace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,9 +5,9 @@ This is a minimal Ghostty terminal config repo. Keep it simple.
 ## What this repo contains
 
 - `configs/ghostty/config` — single Ghostty config file (no modular split)
-- `configs/tmux/tmux.conf` — minimal tmux config (no status bar, Mocha pane borders, mouse on)
+- `configs/tmux/tmux.conf` — minimal tmux config (window hint status bar, Mocha pane borders, mouse on)
 - `scripts/font-picker.fish` — fish font picker function
-- `scripts/dev.fish` — fish function that launches the tmux dev layout (claude left, nu right)
+- `scripts/dev.fish` — fish function that launches the tmux dev workspace (`main`, `codex-agy`, `nushell`)
 - `scripts/install.sh` / `uninstall.sh` — deploy/remove scripts
 - `configs/ghostty/catppuccin-mocha.conf` — Mocha palette reference (not deployed)
 
@@ -35,14 +35,14 @@ shellcheck applies only to the `.sh` scripts; the `.fish` functions (`font-picke
 
 - Shell: fish (primary), nushell (secondary). No zsh.
 - Terminal: Ghostty 1.3.1 on Ubuntu 26.04.
-- Left split: `claude` (Claude Code). Right split: `fish` → `nu`.
+- tmux dev workspace: `main` has `claude` left and `fish` right; `codex-agy` has `codex` left and `agy` right; `nushell` runs `nu` full-screen.
 - Font picker: `font-picker` fish function (zenity + SIGUSR2 reload).
 
 ## tmux integration
 
 - `configs/tmux/tmux.conf` — minimal tmux config for use inside Ghostty
-- `scripts/dev.fish` — fish function that creates the dev layout (claude left, nu right)
+- `scripts/dev.fish` — fish function that creates three tmux windows: `main`, `codex-agy`, and `nushell`
 - tmux is installed via `sudo apt install tmux` (not managed by this repo)
-- Status bar is intentionally OFF (`set -g status off`) — do not re-enable
+- Status bar is intentionally minimal and shows window-switching hints.
 - Pane borders use Catppuccin Mocha surface0 (#313244) and mauve (#cba6f7)
 - Do NOT configure tmux splits inside Ghostty native splits — choose one layer only

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # ghostty-config-files
 
-Ghostty terminal config for a Fish + Nushell + Claude Code workflow on Ubuntu.
-Uses tmux inside Ghostty for scripted split layout (claude left, nushell right).
+Ghostty terminal config for a Fish + Nushell + AI coding workflow on Ubuntu.
+Uses tmux inside Ghostty for a scripted dev workspace.
 
 ## What's included
 
 - `configs/ghostty/config` — single consolidated Ghostty config (Catppuccin Mocha, 80% opacity, no blur)
 - `configs/ghostty/catppuccin-mocha.conf` — Mocha palette reference (not deployed to `~/.config/ghostty/`)
-- `configs/tmux/tmux.conf` — minimal tmux config (no status bar, Mocha pane borders, mouse on)
-- `scripts/dev.fish` — fish function: run `dev` to launch the split layout automatically
+- `configs/tmux/tmux.conf` — minimal tmux config (window hint status bar, Mocha pane borders, mouse on)
+- `scripts/dev.fish` — fish function: run `dev` to launch the tmux dev workspace automatically
 - `scripts/font-picker.fish` — fish function to pick a Nerd Font via zenity with live reload
 - `scripts/install.sh` — deploys all configs + installs fish functions
 - `scripts/uninstall.sh` — reverses install, restores backup
@@ -35,16 +35,30 @@ dev
 This launches tmux inside Ghostty and automatically creates:
 
 ```
-┌─────────────────────┬──────────────────┐
-│   claude (left)     │   nushell (right)│
-│   50%               │   50%            │
-└─────────────────────┴──────────────────┘
+tmux session: dev
+
+1:main
+┌────────────────────────────────────────┬────────────────────┐
+│ claude                                 │ fish               │
+└────────────────────────────────────────┴────────────────────┘
+
+2:codex-agy
+┌──────────────────────────────┬──────────────────────────────┐
+│ codex                        │ agy                          │
+└──────────────────────────────┴──────────────────────────────┘
+
+3:nushell
+┌─────────────────────────────────────────────────────────────┐
+│ nu                                                          │
+└─────────────────────────────────────────────────────────────┘
 ```
 
 | Action | How |
 |--------|-----|
-| Launch dev layout | `dev` |
+| Launch dev workspace | `dev` |
 | Navigate splits | mouse click or tmux prefix + arrow |
+| List tmux windows | tmux prefix + `w` |
+| Switch tmux windows | tmux prefix + `1`, `2`, or `3` |
 | Pick a different font | `font-picker` (zenity list) |
 | Reload Ghostty config | `ctrl+shift+,` or `pkill -SIGUSR2 ghostty` |
 | New Ghostty tab | `ctrl+shift+t` |
@@ -52,7 +66,7 @@ This launches tmux inside Ghostty and automatically creates:
 ## How it works
 
 tmux runs inside Ghostty as a process. Ghostty handles the window/tabs/opacity;
-tmux handles the splits and scripted layout. The status bar is hidden (`set -g status off`)
+tmux handles the splits and scripted layout. The status bar shows window switching hints,
 and pane borders use Catppuccin Mocha surface colors so it looks clean.
 
 ## Installed Nerd Fonts

--- a/configs/ghostty/config
+++ b/configs/ghostty/config
@@ -1,4 +1,4 @@
-# Ghostty Configuration - Fish + Nushell + Claude Code workflow
+# Ghostty Configuration - Fish + Nushell + AI coding workflow
 # managed-by: ghostty-config-files
 # Ghostty 1.3.1 on Ubuntu 26.04. Single consolidated file (no modular includes).
 # Reload after edits: press ctrl+shift+, (default reload_config keybind)
@@ -56,7 +56,7 @@ window-new-tab-position = end
 
 clipboard-trim-trailing-spaces = true
 clipboard-paste-protection = true
-copy-on-select = true
+copy-on-select = clipboard
 
 # KEYBINDS - ctrl+alt+d splits right; ctrl+alt+left/right navigates splits.
 # ctrl+shift+, (reload_config) is a built-in default and is NOT redefined here.

--- a/configs/tmux/tmux.conf
+++ b/configs/tmux/tmux.conf
@@ -1,10 +1,27 @@
 # tmux configuration — minimal, inside Ghostty
 # managed-by: ghostty-config-files
 # Install: scripts/install.sh deploys this to ~/.config/tmux/tmux.conf
-# Launch dev layout: run `dev` in fish
+# Launch dev workspace: run `dev` in fish
 
-# No status bar — clean look inside Ghostty
-set -g status off
+# Minimal status bar with window-switching hints.
+set -g status on
+set -g status-position bottom
+set -g status-style fg=#cdd6f4,bg=#181825
+set -g status-left ' #S | '
+set -g status-left-length 20
+set -g status-right ' keys: Ctrl+b, then 1/2/3 n/p w | %H:%M '
+set -g status-right-length 100
+set -g window-status-format ' #I:#W '
+set -g window-status-current-format ' #I:#W* '
+
+# Window switching. Prefix keys are normally sequential: Ctrl+b, release, key.
+set -g prefix C-b
+bind-key 1 select-window -t :=1
+bind-key 2 select-window -t :=2
+bind-key 3 select-window -t :=3
+bind-key n next-window
+bind-key p previous-window
+bind-key w choose-window
 
 # Pane borders — Catppuccin Mocha surface/mauve
 set -g pane-border-style fg=#313244
@@ -16,7 +33,6 @@ set -ag terminal-overrides ",ghostty:RGB"
 
 # Mouse support (click to focus pane, scroll)
 set -g mouse on
-set -g set-clipboard on
 
 # Allow apps to set the system clipboard via OSC 52 (fixes right-click copy)
 set -g set-clipboard on

--- a/scripts/dev.fish
+++ b/scripts/dev.fish
@@ -1,24 +1,38 @@
 # scripts/dev.fish (symlinked to ~/.config/fish/functions/dev.fish at install time)
-# Launches the dev layout: claude on the left, nushell on the right (50/50 split).
-# Requires tmux. If a 'dev' session already exists, reattaches to it.
+# Launches the dev workspace:
+#   1:main      claude (left) / fish (right)
+#   2:codex-agy codex  (left) / agy  (right)
+#   3:nushell   nu     (full window)
+# Requires tmux.
 
-function dev --description 'Launch tmux dev layout: claude left, nushell right'
+function dev --description 'Launch tmux dev workspace: main, codex-agy, nushell'
     if not command -q tmux
         echo "tmux not installed. Run: sudo apt install tmux"
         return 1
     end
 
-    # Reattach if session already exists
-    if tmux has-session -t dev 2>/dev/null
-        tmux attach -t dev
-        return
-    end
+    # Always kill and recreate — use 'tmux attach -t dev' to reattach manually.
+    tmux kill-session -t dev 2>/dev/null
 
-    # New session: left pane = claude, right pane = nushell (50/50)
-    tmux new-session -d -s dev
-    tmux send-keys -t dev "claude" Enter
-    tmux split-window -t dev -h -p 50
-    tmux send-keys -t dev "nu" Enter
-    tmux select-pane -t dev:1.1
+    tmux new-session -d -s dev -n main
+
+    # Capture stable pane IDs via -P -F; tmux pane indexes change after splits.
+    set -l claude (tmux display-message -p -t dev:main '#{pane_id}')
+    set -l fish_pane (tmux split-window -h -t "$claude" -p 35 -P -F '#{pane_id}')
+    tmux send-keys -t "$claude" 'claude' Enter
+    tmux send-keys -t "$fish_pane" 'fish' Enter
+
+    tmux new-window -t dev:2 -n codex-agy
+    set -l codex (tmux display-message -p -t dev:codex-agy '#{pane_id}')
+    set -l agy (tmux split-window -h -t "$codex" -p 50 -P -F '#{pane_id}')
+    tmux send-keys -t "$codex" 'codex' Enter
+    tmux send-keys -t "$agy" 'agy' Enter
+
+    tmux new-window -t dev:3 -n nushell
+    set -l nu (tmux display-message -p -t dev:nushell '#{pane_id}')
+    tmux send-keys -t "$nu" 'nu' Enter
+
+    tmux select-window -t dev:main
+    tmux select-pane -t "$fish_pane"
     tmux attach -t dev
 end

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -73,7 +73,7 @@ cat <<'MSG'
 Next steps:
   1. Install tmux if not present:  sudo apt install tmux
   2. Open Ghostty and run:  dev
-     -> splits into claude (left) and nushell (right) automatically.
+     -> creates tmux windows: main (claude/fish), codex-agy (codex/agy), nushell (nu).
   3. Run `font-picker` to change the Ghostty font (zenity list + live reload).
   4. Reload Ghostty config: ctrl+shift+,  (or: pkill -SIGUSR2 ghostty)
 MSG

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -12,7 +12,7 @@ DST_DEV="$HOME/.config/fish/functions/dev.fish"
 
 # Ghostty config: detect via managed-by marker or stale symlink
 if [ -f "$DST_GHOSTTY" ] && grep -q 'managed-by: ghostty-config-files' "$DST_GHOSTTY" 2>/dev/null; then
-    LATEST_BAK=$(ls -t "${DST_GHOSTTY}.bak."* 2>/dev/null | head -1 || true)
+    LATEST_BAK=$(find "$(dirname "$DST_GHOSTTY")" -maxdepth 1 -type f -name "$(basename "$DST_GHOSTTY").bak.*" -printf '%T@ %p\n' | sort -nr | head -n 1 | cut -d' ' -f2-)
     rm -f "$DST_GHOSTTY"
     if [ -n "$LATEST_BAK" ]; then
         mv "$LATEST_BAK" "$DST_GHOSTTY"


### PR DESCRIPTION
## Summary

Updates the Ghostty/tmux workflow from a single split layout into a three-window tmux dev workspace:

- main: claude/fish
- codex-agy: codex/agy
- nushell: nu

Also adds a minimal tmux status bar with official prefix-key window hints and a clock, keeps clipboard copy-on-select behavior explicit, and fixes the existing ShellCheck warning in uninstall.sh.

## Validation

- `ghostty +validate-config --config-file=configs/ghostty/config`
- `shellcheck scripts/install.sh scripts/uninstall.sh`
- `fish -n scripts/dev.fish`
- tmux config sourced in a throwaway tmux server