### PR TITLE
feat(tmux): allow OSC sequence passthrough for Claude Code status line

### DIFF
--- a/configs/tmux/tmux.conf
+++ b/configs/tmux/tmux.conf
@@ -36,6 +36,8 @@ set -g mouse on
 
 # Allow apps to set the system clipboard via OSC 52 (fixes right-click copy)
 set -g set-clipboard on
+# Allow panes to pass OSC sequences through to the outer terminal (needed for Claude Code status line)
+set -g allow-passthrough on
 
 # No escape key delay (important for Claude Code / vim)
 set -s escape-time 0


### PR DESCRIPTION
## Summary
- Adds \`set -g allow-passthrough on\` to tmux.conf
- Allows panes to pass OSC sequences through to the outer terminal, required for the Claude Code status line to render correctly

## Test plan
- [ ] Start a new tmux session and confirm Claude Code status line renders in the status bar