### PR TITLE
chore: add .envrc.local.example template for remote machine setup

### DIFF
--- a/.envrc.local.example
+++ b/.envrc.local.example
@@ -1,0 +1,61 @@
+# shellcheck shell=bash
+# Copy to .envrc.local and adjust token file paths for this machine.
+# .envrc.local must stay untracked. Do not paste secret values into this file.
+# Run `direnv allow` after editing .envrc.local.
+
+load_secret() {
+  local var_name="$1"
+  local token_file="$2"
+  local value
+
+  if [ -r "$token_file" ]; then
+    value="$(tr -d '\r\n' < "$token_file")"
+    export "$var_name=$value"
+  fi
+}
+
+# --- GitHub CLI (gh) ---
+load_secret GH_TOKEN "/home/kkk/.github/gh.token"
+if [ -n "${GH_TOKEN:-}" ]; then
+  export GITHUB_TOKEN="$GH_TOKEN"
+fi
+
+# --- Billing API ---
+# shellcheck source=/dev/null
+[ -r "/home/kkk/Apps/.git/billing-api.token" ] && source "/home/kkk/Apps/.git/billing-api.token"
+
+# --- Documentation / MCP ---
+load_secret CONTEXT7_API_KEY "/home/kkk/.context7/context7.token"
+
+# --- Model APIs ---
+load_secret ANTHROPIC_API_KEY "/home/kkk/.anthropic/anthropic.token"
+load_secret OPENAI_API_KEY "/home/kkk/.openai/openai.token"
+
+# --- Hugging Face CLI (hf / huggingface-cli) ---
+# Hugging Face officially stores the CLI token here when HF_HOME/HF_TOKEN_PATH are unset.
+load_secret HF_TOKEN "/home/kkk/.cache/huggingface/token"
+if [ -n "${HF_TOKEN:-}" ]; then
+  export HUGGINGFACE_TOKEN="$HF_TOKEN"
+fi
+
+# --- Codacy CLI ---
+load_secret CODACY_ACCOUNT_TOKEN "/home/kkk/.codacy/account-token"
+load_secret CODACY_API_TOKEN "/home/kkk/.codacy/api-token"
+if [ -z "${CODACY_API_TOKEN:-}" ] && [ -n "${CODACY_ACCOUNT_TOKEN:-}" ]; then
+  export CODACY_API_TOKEN="$CODACY_ACCOUNT_TOKEN"
+fi
+load_secret CODACY_PROJECT_TOKEN "/home/kkk/.codacy/kairin-ghostty-config-files.project-token"
+export CODACY_ORGANIZATION_PROVIDER="gh"
+export CODACY_USERNAME="kairin"
+export CODACY_PROJECT_NAME="ghostty-config-files"
+
+# --- Project-specific optional secrets ---
+load_secret HAMPERS_PLUMBER_WEBHOOK_ENCRYPTION_KEY "/home/kkk/.hampers/plumber-webhook-encryption.token"
+load_secret FOR_EDU_SG_Key_key_live_v1_ "/home/kkk/.for-edu-sg/key_live_v1.token"
+
+# Harness (app.harness.io) project token.
+load_secret HARNESS_API_KEY "/home/kkk/.harness/api.token"
+load_secret HARNESS_PLATFORM_API_KEY "/home/kkk/.harness/platform-api.token"
+if [ -z "${HARNESS_PLATFORM_API_KEY:-}" ] && [ -n "${HARNESS_API_KEY:-}" ]; then
+  export HARNESS_PLATFORM_API_KEY="$HARNESS_API_KEY"
+fi

--- a/configs/tmux/tmux.conf
+++ b/configs/tmux/tmux.conf
@@ -36,6 +36,8 @@ set -g mouse on
 
 # Allow apps to set the system clipboard via OSC 52 (fixes right-click copy)
 set -g set-clipboard on
+# Allow panes to pass OSC sequences through to the outer terminal (needed for Claude Code status line)
+set -g allow-passthrough on
 
 # No escape key delay (important for Claude Code / vim)
 set -s escape-time 0


### PR DESCRIPTION
Adds `.envrc.local.example` as a reference template showing how to configure `.envrc.local` on remote machines. No secrets — only token file paths.