### PR TITLE
chore: update envrc example to use GITHUB_MCP_TOKEN

### DIFF
--- a/.envrc.local.example
+++ b/.envrc.local.example
@@ -15,10 +15,7 @@ load_secret() {
 }
 
 # --- GitHub CLI (gh) ---
-load_secret GH_TOKEN "/home/kkk/.github/gh.token"
-if [ -n "${GH_TOKEN:-}" ]; then
-  export GITHUB_TOKEN="$GH_TOKEN"
-fi
+load_secret GITHUB_MCP_TOKEN "/home/kkk/.github/gh.token"
 
 # --- Billing API ---
 # shellcheck source=/dev/null


### PR DESCRIPTION
Updates `.envrc.local.example` to use `GITHUB_MCP_TOKEN` instead of reserved `GH_TOKEN`/`GITHUB_TOKEN`. Also includes tmux OSC passthrough and .envrc.local.example template from prior work.