### PR TITLE
feat(dev): make dev a tmux toggle + reconcile og-tools workspace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This is a minimal Ghostty terminal config repo. Keep it simple.
 - `configs/ghostty/config` — single Ghostty config file (no modular split)
 - `configs/tmux/tmux.conf` — minimal tmux config (window hint status bar, Mocha pane borders, mouse on)
 - `scripts/font-picker.fish` — fish font picker function
-- `scripts/dev.fish` — fish function that launches the tmux dev workspace (`main`, `codex-agy`, `nushell`)
+- `scripts/dev.fish` — fish function that toggles the `og-tools` tmux session (`claude`, `codex`, `agy`; rooted in `~/Apps/OG-tools`)
 - `scripts/install.sh` / `uninstall.sh` — deploy/remove scripts
 - `configs/ghostty/catppuccin-mocha.conf` — Mocha palette reference (not deployed)
 
@@ -35,13 +35,14 @@ shellcheck applies only to the `.sh` scripts; the `.fish` functions (`font-picke
 
 - Shell: fish (primary), nushell (secondary). No zsh.
 - Terminal: Ghostty 1.3.1 on Ubuntu 26.04.
-- tmux dev workspace: `main` has `claude` left and `fish` right; `codex-agy` has `codex` left and `agy` right; `nushell` runs `nu` full-screen.
+- tmux dev session `og-tools` (rooted in `~/Apps/OG-tools`): `claude` window has `claude` left and `fish` right; `codex` window runs `codex`; `agy` window runs `agy`.
+- `dev` is a toggle: outside tmux it attaches (creating the session first if needed); inside tmux it `detach-client`s so the session keeps running in the background. `dev reset` kills the session and rebuilds it fresh.
 - Font picker: `font-picker` fish function (zenity + SIGUSR2 reload).
 
 ## tmux integration
 
 - `configs/tmux/tmux.conf` — minimal tmux config for use inside Ghostty
-- `scripts/dev.fish` — fish function that creates three tmux windows: `main`, `codex-agy`, and `nushell`
+- `scripts/dev.fish` — fish function that toggles the `og-tools` session (rooted in `~/Apps/OG-tools`): `claude` (claude/fish split), `codex`, `agy`. Attach/detach on repeat; `dev reset` rebuilds. Run `dev reset` from outside tmux or a status-bar `run-shell` binding — not from a pane inside the session it is killing.
 - tmux is installed via `sudo apt install tmux` (not managed by this repo)
 - Status bar is intentionally minimal and shows window-switching hints.
 - Pane borders use Catppuccin Mocha surface0 (#313244) and mauve (#cba6f7)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- `dev.fish` now manages the `og-tools` session (windows `claude`, `codex`, `agy`, rooted in `~/Apps/OG-tools`) and is a toggle: outside tmux it attaches (creating the session if needed), inside tmux it detaches so panes keep running in the background. Added `dev reset` to force a fresh rebuild. Repo file, live `~/.config/fish/functions/dev.fish` symlink, and docs reconciled — the live file had drifted to a detached standalone copy.
+
 ### Fixed
 - `clipboard-trim-trailing-spaces` set to `false` — was silently dropping the last character when copied text ended with a space (nushell output, etc.)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Uses tmux inside Ghostty for a scripted dev workspace.
 - `configs/ghostty/config` — single consolidated Ghostty config (Catppuccin Mocha, 80% opacity, no blur)
 - `configs/ghostty/catppuccin-mocha.conf` — Mocha palette reference (not deployed to `~/.config/ghostty/`)
 - `configs/tmux/tmux.conf` — minimal tmux config (window hint status bar, Mocha pane borders, mouse on)
-- `scripts/dev.fish` — fish function: run `dev` to launch the tmux dev workspace automatically
+- `scripts/dev.fish` — fish function: `dev` toggles the `og-tools` tmux session (`claude`/`codex`/`agy`, rooted in `~/Apps/OG-tools`)
 - `scripts/font-picker.fish` — fish function to pick a Nerd Font via zenity with live reload
 - `scripts/install.sh` — deploys all configs + installs fish functions
 - `scripts/uninstall.sh` — reverses install, restores backup
@@ -32,30 +32,39 @@ Open Ghostty and type:
 dev
 ```
 
-This launches tmux inside Ghostty and automatically creates:
+`dev` is a **toggle**:
+
+- First `dev` (in a plain terminal) builds the session and attaches.
+- `dev` again while attached **detaches** — the panes keep running in the background and you drop back to the normal terminal.
+- `dev` once more **reattaches** to the same session, exactly as you left it.
+- `dev reset` tears the session down and rebuilds it fresh (new `claude`/`codex`/`agy`).
+
+It launches tmux inside Ghostty and creates the `og-tools` session (all panes rooted in `~/Apps/OG-tools`):
 
 ```
-tmux session: dev
+tmux session: og-tools
 
-1:main
+1:claude
 ┌────────────────────────────────────────┬────────────────────┐
 │ claude                                 │ fish               │
 └────────────────────────────────────────┴────────────────────┘
 
-2:codex-agy
-┌──────────────────────────────┬──────────────────────────────┐
-│ codex                        │ agy                          │
-└──────────────────────────────┴──────────────────────────────┘
-
-3:nushell
+2:codex
 ┌─────────────────────────────────────────────────────────────┐
-│ nu                                                          │
+│ codex                                                       │
+└─────────────────────────────────────────────────────────────┘
+
+3:agy
+┌─────────────────────────────────────────────────────────────┐
+│ agy                                                         │
 └─────────────────────────────────────────────────────────────┘
 ```
 
 | Action | How |
 |--------|-----|
-| Launch dev workspace | `dev` |
+| Launch / reattach dev workspace | `dev` |
+| Detach (hide) dev workspace | `dev` again while attached |
+| Rebuild dev workspace from scratch | `dev reset` |
 | Navigate splits | mouse click or tmux prefix + arrow |
 | List tmux windows | tmux prefix + `w` |
 | Switch tmux windows | tmux prefix + `1`, `2`, or `3` |

--- a/scripts/dev.fish
+++ b/scripts/dev.fish
@@ -1,38 +1,51 @@
 # scripts/dev.fish (symlinked to ~/.config/fish/functions/dev.fish at install time)
-# Launches the dev workspace:
-#   1:main      claude (left) / fish (right)
-#   2:codex-agy codex  (left) / agy  (right)
-#   3:nushell   nu     (full window)
-# Requires tmux.
+# Toggles the og-tools tmux dev session, rooted at ~/Apps/OG-tools:
+#   claude  claude (left) / fish (right)
+#   codex   codex
+#   agy     agy
+# `dev` inside tmux detaches (hides); outside it reattaches, creating the session if needed.
+# `dev reset` kills the session and rebuilds it. Requires tmux.
 
-function dev --description 'Launch tmux dev workspace: main, codex-agy, nushell'
+function dev --description 'Toggle the og-tools tmux dev session (dev reset rebuilds)'
+    set -l session og-tools
+    set -l project /home/kkk/Apps/OG-tools
+
     if not command -q tmux
         echo "tmux not installed. Run: sudo apt install tmux"
         return 1
     end
 
-    # Always kill and recreate — use 'tmux attach -t dev' to reattach manually.
-    tmux kill-session -t dev 2>/dev/null
+    # 'dev reset' tears the session down so the block below rebuilds it.
+    if test "$argv[1]" = reset
+        tmux kill-session -t "$session" 2>/dev/null
+    else
+        # Toggle: inside tmux -> hide (detach); session already running -> reattach.
+        if set -q TMUX
+            tmux detach-client
+            return
+        end
+        if tmux has-session -t "$session" 2>/dev/null
+            tmux attach-session -t "$session"
+            return
+        end
+    end
 
-    tmux new-session -d -s dev -n main
+    tmux new-session -d -s "$session" -c "$project" -n claude "claude"
+    tmux set-option -t "$session" status on
+    tmux set-option -t "$session" status-position bottom
+    tmux set-option -t "$session" mouse on
 
-    # Capture stable pane IDs via -P -F; tmux pane indexes change after splits.
-    set -l claude (tmux display-message -p -t dev:main '#{pane_id}')
-    set -l fish_pane (tmux split-window -h -t "$claude" -p 35 -P -F '#{pane_id}')
-    tmux send-keys -t "$claude" 'claude' Enter
-    tmux send-keys -t "$fish_pane" 'fish' Enter
+    tmux split-window -h -p 50 -t "$session:claude" -c "$project" "fish"
+    tmux select-pane -t "$session:claude.{left}"
 
-    tmux new-window -t dev:2 -n codex-agy
-    set -l codex (tmux display-message -p -t dev:codex-agy '#{pane_id}')
-    set -l agy (tmux split-window -h -t "$codex" -p 50 -P -F '#{pane_id}')
-    tmux send-keys -t "$codex" 'codex' Enter
-    tmux send-keys -t "$agy" 'agy' Enter
+    tmux new-window -t "$session:" -c "$project" -n codex "codex"
+    tmux new-window -t "$session:" -c "$project" -n agy "agy"
+    tmux select-window -t "$session:claude"
 
-    tmux new-window -t dev:3 -n nushell
-    set -l nu (tmux display-message -p -t dev:nushell '#{pane_id}')
-    tmux send-keys -t "$nu" 'nu' Enter
-
-    tmux select-window -t dev:main
-    tmux select-pane -t "$fish_pane"
-    tmux attach -t dev
+    # 'dev reset' from inside a *different* tmux session -> switch; else attach.
+    if set -q TMUX
+        tmux switch-client -t "$session"
+    else
+        tmux attach-session -t "$session"
+    end
 end

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -73,7 +73,8 @@ cat <<'MSG'
 Next steps:
   1. Install tmux if not present:  sudo apt install tmux
   2. Open Ghostty and run:  dev
-     -> creates tmux windows: main (claude/fish), codex-agy (codex/agy), nushell (nu).
+     -> toggles the og-tools tmux session: claude (claude/fish), codex, agy.
+        Run `dev` again to detach, `dev` to reattach, `dev reset` to rebuild.
   3. Run `font-picker` to change the Ghostty font (zenity list + live reload).
   4. Reload Ghostty config: ctrl+shift+,  (or: pkill -SIGUSR2 ghostty)
 MSG


### PR DESCRIPTION
## Summary

Makes the `dev` fish function a **toggle** and reconciles the repo with the live function, which had silently drifted to a standalone copy.

### Behavior
- `dev` outside tmux → attaches to the `og-tools` session (creates it if missing)
- `dev` inside the session → **detaches** (panes keep running in the background)
- `dev` again → reattaches exactly as left
- `dev reset` → kills and rebuilds the session from scratch

### Why the reconcile
`~/.config/fish/functions/dev.fish` was a plain regular file (not the install symlink), managing the real `og-tools` workspace (windows `claude`/`codex`/`agy`, rooted in `~/Apps/OG-tools`). The repo's `scripts/dev.fish` still described a dead `dev`/`main`/`codex-agy`/`nushell` layout, so repo edits never reached the live command. This rewrites the repo file to match the `og-tools` reality; the install symlink now reconnects live = repo.

### Changes
- `scripts/dev.fish` — og-tools toggle + `dev reset`
- `scripts/install.sh` — "Next steps" text updated
- `README.md` — workflow prose, ASCII diagram, actions table → og-tools
- `AGENTS.md` (→ CLAUDE.md, GEMINI.md) — workspace + toggle described
- `CHANGELOG.md` — `[Unreleased]` entry

### Validation
- `fish -n` passes on the repo file and the live symlink
- `~/.config/fish/functions/dev.fish` re-symlinked to the repo
- CLAUDE.md / GEMINI.md symlinks intact

Note: `dev reset` must be run from outside the session it kills (a pane inside it dies mid-function).

🤖 Generated with [Claude Code](https://claude.com/claude-code)