### PR TITLE
feat(dev): per-directory tmux sessions with last/ls/reset

### DIFF
--- a/scripts/dev.fish
+++ b/scripts/dev.fish
@@ -1,32 +1,84 @@
 # scripts/dev.fish (symlinked to ~/.config/fish/functions/dev.fish at install time)
-# Toggles the og-tools tmux dev session, rooted at ~/Apps/OG-tools:
+# Toggles a per-directory tmux dev session, rooted at the directory you launch from:
 #   claude  claude (left) / fish (right)
 #   codex   codex
 #   agy     agy
-# `dev` inside tmux detaches (hides); outside it reattaches, creating the session if needed.
-# `dev reset` kills the session and rebuilds it. Requires tmux.
+# Each directory gets its own session named dev-<basename>-<8-char sha1 of full path>,
+# so two dirs with the same basename (~/work/web vs ~/play/web) never collide.
+# Before reattaching, the session's recorded root dir is verified against the
+# current dir; on any mismatch the stale session is rebuilt here. `dev` inside
+# tmux detaches (hides); outside it reattaches, creating the session if needed.
+# `dev reset` kills the current directory's session and rebuilds it.
+# `dev last` jumps to the most-recently-used dev session (no need to recall its dir).
+# `dev ls`   lists all dev sessions with their root directories. Requires tmux.
 
-function dev --description 'Toggle the og-tools tmux dev session (dev reset rebuilds)'
-    set -l session og-tools
-    set -l project /home/kkk/Apps/OG-tools
-
+function dev --description 'Toggle a per-directory tmux dev session (last/ls/reset)'
     if not command -q tmux
         echo "tmux not installed. Run: sudo apt install tmux"
         return 1
     end
 
+    # 'dev ls' — show every dev session and the directory it is rooted at.
+    if test "$argv[1]" = ls
+        set -l rows (tmux list-sessions -F '#{session_name}	#{session_path}' 2>/dev/null \
+            | string match --entire 'dev-*')
+        if test -z "$rows"
+            echo "No dev sessions running."
+            return 1
+        end
+        printf '%s\n' $rows
+        return 0
+    end
+
+    # 'dev last' — attach the most recently used dev session, wherever it roots.
+    if test "$argv[1]" = last
+        set -l target (tmux list-sessions -F '#{session_last_attached} #{session_name}' 2>/dev/null \
+            | string match --entire '* dev-*' \
+            | sort -rn \
+            | head -1 \
+            | string replace -r '^[0-9]* ' '')
+        if test -z "$target"
+            echo "No dev sessions running."
+            return 1
+        end
+        if set -q TMUX
+            tmux switch-client -t "$target"
+        else
+            tmux attach-session -t "$target"
+        end
+        return 0
+    end
+
+    # Resolve symlinks so the same physical dir always maps to the same session,
+    # regardless of which path you cd'd through.
+    set -l project (realpath $PWD)
+
+    # tmux session names can't contain '.' or ':'. Keep the basename for
+    # readability; append a hash of the FULL path so identity is per-path,
+    # not per-basename.
+    set -l hash (echo -n $project | sha1sum | string sub -l 8)
+    set -l session dev-(string replace -ra '[^A-Za-z0-9_-]' '-' (basename $project))-$hash
+
     # 'dev reset' tears the session down so the block below rebuilds it.
     if test "$argv[1]" = reset
         tmux kill-session -t "$session" 2>/dev/null
     else
-        # Toggle: inside tmux -> hide (detach); session already running -> reattach.
+        # Toggle: inside tmux -> hide (detach).
         if set -q TMUX
             tmux detach-client
             return
         end
         if tmux has-session -t "$session" 2>/dev/null
-            tmux attach-session -t "$session"
-            return
+            # Belt and braces: only reattach if the session really roots here.
+            # Guards against any residual name collision or a stale session
+            # whose directory has since been moved/renamed.
+            set -l session_root (tmux display-message -p -t "$session" '#{session_path}')
+            if test "$session_root" = "$project"
+                tmux attach-session -t "$session"
+                return
+            end
+            # Wrong root: it is not this directory's session. Rebuild here.
+            tmux kill-session -t "$session" 2>/dev/null
         end
     end
 


### PR DESCRIPTION
## Summary
- Root each dev session at the launch directory instead of a fixed `~/Apps/OG-tools`
- Name sessions `dev-<basename>-<sha1[0:8]>` so dirs with the same basename never collide
- Verify a session's recorded root before reattaching; rebuild on mismatch
- Add `dev last` (jump to most-recently-used session) and `dev ls` (list sessions with roots)

## Test plan
- `ghostty +validate-config` unaffected (no config change)
- `.fish` functions are not shellcheck-compatible; verified manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)