### PR TITLE
feat(fish): reproducible fish + starship shell env via install.sh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,11 @@ This is a minimal Ghostty terminal config repo. Keep it simple.
 
 - `configs/ghostty/config` — single Ghostty config file (no modular split)
 - `configs/tmux/tmux.conf` — minimal tmux config (window hint status bar, Mocha pane borders, mouse on)
+- `configs/fish/config.fish` — fish interactive env (PATH, fnm, bun, uv/gum/glow completions, fzf, zoxide, starship, mcp-secrets shim)
+- `configs/starship/starship.toml` — Catppuccin Mocha prompt (replaces the old powerlevel10k zsh prompt)
 - `scripts/font-picker.fish` — fish font picker function
 - `scripts/dev.fish` — fish function that toggles the `og-tools` tmux session (`claude`, `codex`, `agy`; rooted in `~/Apps/OG-tools`)
-- `scripts/install.sh` / `uninstall.sh` — deploy/remove scripts
+- `scripts/install.sh` / `uninstall.sh` — deploy/remove scripts (install.sh also sets up the fish shell env; `--no-shell` skips that)
 - `configs/ghostty/catppuccin-mocha.conf` — Mocha palette reference (not deployed)
 
 ## Rules
@@ -19,6 +21,8 @@ This is a minimal Ghostty terminal config repo. Keep it simple.
 - Do NOT set `scrollback-limit` above 50000.
 - Do NOT add `config-reload-on-focus-in` — it is not a valid Ghostty 1.3.1 option and fails validation.
 - Do NOT create new `.sh` scripts; extend install.sh / uninstall.sh instead.
+- `configs/fish/config.fish` and `configs/starship/starship.toml` are SYMLINKED into `~/.config` by install.sh (like the tmux/fish-function symlinks) so `git pull` propagates updates. Never store secrets in them.
+- NEVER put secrets in the repo. `~/.mcp-secrets` is bash-syntax, machine-local, synced out-of-band; config.fish only parses it at startup.
 - NEVER commit directly to main — use a timestamped branch `YYYYMMDD-HHMMSS-description`.
 - Keep `CLAUDE.md` and `GEMINI.md` as symlinks to this file. Never overwrite them with regular files.
 
@@ -29,11 +33,13 @@ ghostty +validate-config --config-file=configs/ghostty/config   # must exit 0
 shellcheck scripts/install.sh scripts/uninstall.sh
 ```
 
-shellcheck applies only to the `.sh` scripts; the `.fish` functions (`font-picker.fish`, `dev.fish`) are not shellcheck-compatible.
+shellcheck applies only to the `.sh` scripts; the `.fish` files (`config.fish`, `font-picker.fish`, `dev.fish`) are not shellcheck-compatible — sanity-check them with `fish --no-execute configs/fish/config.fish` instead.
 
 ## User context
 
-- Shell: fish (primary), nushell (secondary). No zsh.
+- Shell: fish (primary), nushell (secondary). No zsh. Prompt: starship (Catppuccin Mocha), replacing the old powerlevel10k zsh setup.
+- Shell env lives in `configs/fish/config.fish`: PATH (`~/.local/bin`, `~/.bun/bin`), `fnm --use-on-cd`, bun, uv/gum/glow completions, fzf, zoxide (`z`), starship, and a parser for the machine-local bash-syntax `~/.mcp-secrets`.
+- `install.sh` installs fish + zoxide (apt) and starship (userspace `~/.local/bin`), then offers `chsh` to fish. Tolerant of no-sudo / non-interactive runs (warns, never hangs).
 - Terminal: Ghostty 1.3.1 on Ubuntu 26.04.
 - tmux dev session `og-tools` (rooted in `~/Apps/OG-tools`): `claude` window has `claude` left and `fish` right; `codex` window runs `codex`; `agy` window runs `agy`.
 - `dev` is a toggle: outside tmux it attaches (creating the session first if needed); inside tmux it `detach-client`s so the session keeps running in the background. `dev reset` kills the session and rebuilds it fresh.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Fish shell environment captured in the repo for reproducible multi-machine setup: `configs/fish/config.fish` (PATH, fnm, bun, uv/gum/glow completions, fzf, zoxide `z`, starship, and a parser for the machine-local bash-syntax `~/.mcp-secrets`) and `configs/starship/starship.toml` (Catppuccin Mocha prompt, replacing the old powerlevel10k zsh setup).
+- `install.sh` now sets up the fish shell env: installs fish + zoxide (`sudo apt`) and starship (userspace `~/.local/bin`), symlinks `config.fish`/`starship.toml` into `~/.config`, and offers `chsh` to fish. Idempotent and tolerant of no-sudo / non-interactive runs. `--no-shell` skips it; `uninstall.sh` removes the new symlinks (apt/starship/chsh left in place).
+
 ### Changed
 - `dev.fish` now manages the `og-tools` session (windows `claude`, `codex`, `agy`, rooted in `~/Apps/OG-tools`) and is a toggle: outside tmux it attaches (creating the session if needed), inside tmux it detaches so panes keep running in the background. Added `dev reset` to force a fresh rebuild. Repo file, live `~/.config/fish/functions/dev.fish` symlink, and docs reconciled — the live file had drifted to a detached standalone copy.
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ Uses tmux inside Ghostty for a scripted dev workspace.
 - `configs/ghostty/config` — single consolidated Ghostty config (Catppuccin Mocha, 80% opacity, no blur)
 - `configs/ghostty/catppuccin-mocha.conf` — Mocha palette reference (not deployed to `~/.config/ghostty/`)
 - `configs/tmux/tmux.conf` — minimal tmux config (window hint status bar, Mocha pane borders, mouse on)
+- `configs/fish/config.fish` — fish interactive env: PATH, fnm, bun, uv/gum/glow completions, fzf, zoxide (`z`), starship, and a `~/.mcp-secrets` parser
+- `configs/starship/starship.toml` — Catppuccin Mocha prompt (replaces powerlevel10k)
 - `scripts/dev.fish` — fish function: `dev` toggles the `og-tools` tmux session (`claude`/`codex`/`agy`, rooted in `~/Apps/OG-tools`)
 - `scripts/font-picker.fish` — fish function to pick a Nerd Font via zenity with live reload
-- `scripts/install.sh` — deploys all configs + installs fish functions
+- `scripts/install.sh` — deploys all configs, installs fish functions, and sets up the fish shell env (`--no-shell` skips the shell setup)
 - `scripts/uninstall.sh` — reverses install, restores backup
 
 ## Setup
@@ -22,7 +24,23 @@ cd ~/Apps/ghostty-config-files
 ./scripts/install.sh
 ```
 
-Re-run with `--force` to overwrite an existing Ghostty config (a timestamped backup is made).
+`install.sh` deploys the Ghostty/tmux/fish configs and sets up the fish shell environment:
+it installs **fish** + **zoxide** (`sudo apt`) and **starship** (userspace `~/.local/bin`),
+symlinks `config.fish`/`starship.toml` into `~/.config`, and offers to `chsh` to fish.
+It is idempotent and degrades gracefully without sudo (it warns instead of failing).
+Pass `--no-shell` to deploy only the Ghostty/tmux configs. Re-run with `--force` to
+overwrite an existing Ghostty config (a timestamped backup is made).
+
+### Shell environment & secrets
+
+`config.fish` is symlinked into `~/.config/fish/`, so `git pull` keeps every machine in sync.
+It loads `~/.mcp-secrets` if present — a **machine-local**, bash-syntax (`export KEY=VALUE`)
+file synced out-of-band and **never committed** to this repo (fish parses its `export`
+lines natively). After install, set fish as your login shell and re-login:
+
+```bash
+chsh -s "$(command -v fish)"
+```
 
 ## Daily workflow
 

--- a/configs/fish/config.fish
+++ b/configs/fish/config.fish
@@ -1,0 +1,61 @@
+# config.fish — managed-by: ghostty-config-files
+# Interactive shell environment for the Fish-primary workflow.
+# Symlinked to ~/.config/fish/config.fish by scripts/install.sh, so `git pull`
+# propagates changes. Mirrors the env this repo's machines previously kept in
+# ~/.zshrc (Oh My Zsh + powerlevel10k), now ported to fish + starship.
+#
+# Everything here is guarded with `type -q` so a machine missing a given tool
+# still starts a clean shell. No secrets live in this file (see mcp-secrets below).
+
+# --- PATH ---------------------------------------------------------------------
+# fish_add_path is idempotent; earlier args take precedence (end up first).
+fish_add_path $HOME/.local/bin $HOME/.bun/bin
+
+# --- bun ----------------------------------------------------------------------
+set -gx BUN_INSTALL $HOME/.bun
+# (bun installs its own fish completions into ~/.config/fish/completions)
+
+# --- fnm (Fast Node Manager) --------------------------------------------------
+if type -q fnm
+    fnm env --use-on-cd | source
+end
+
+# --- Tool completions ---------------------------------------------------------
+if type -q uv
+    uv generate-shell-completion fish | source
+end
+if type -q gum
+    gum completion fish | source
+end
+if type -q glow
+    glow completion fish | source
+end
+
+# --- fzf (Ctrl+R history, Ctrl+T files) — fzf >= 0.48 -------------------------
+if type -q fzf
+    fzf --fish | source
+end
+
+# --- zoxide (replaces the old zsh `z` plugin; provides `z` / `zi`) ------------
+if type -q zoxide
+    zoxide init fish | source
+end
+
+# --- Starship prompt (replaces powerlevel10k; cross-shell) --------------------
+if type -q starship
+    starship init fish | source
+end
+
+# --- MCP secrets --------------------------------------------------------------
+# ~/.mcp-secrets is bash syntax (`export KEY=VALUE`) and is synced between
+# machines out-of-band. It is NEVER committed to this repo. Fish cannot `source`
+# bash export syntax, so parse the export lines and re-export them natively.
+if test -f "$HOME/.mcp-secrets"
+    for line in (grep -E '^[[:space:]]*export[[:space:]]' "$HOME/.mcp-secrets")
+        set -l kv (string replace -r '^[[:space:]]*export[[:space:]]+' '' -- $line)
+        set -l parts (string split -m1 '=' -- $kv)
+        if test (count $parts) -eq 2
+            set -gx $parts[1] (string trim --chars=\"\' -- $parts[2])
+        end
+    end
+end

--- a/configs/starship/starship.toml
+++ b/configs/starship/starship.toml
@@ -1,0 +1,118 @@
+# starship.toml — managed-by: ghostty-config-files
+# Catppuccin Mocha prompt to match the repo's Ghostty/tmux theme.
+# Symlinked to ~/.config/starship.toml by scripts/install.sh.
+# Replaces the old powerlevel10k prompt (p10k config is zsh-specific, not portable).
+
+palette = "catppuccin_mocha"
+
+format = """
+[](surface0)\
+$os\
+$username\
+[](bg:peach fg:surface0)\
+$directory\
+[](fg:peach bg:green)\
+$git_branch\
+$git_status\
+[](fg:green bg:teal)\
+$nodejs\
+$python\
+$golang\
+$rust\
+[](fg:teal bg:surface0)\
+$cmd_duration\
+[ ](fg:surface0)\
+$line_break\
+$character"""
+
+[os]
+disabled = false
+style = "bg:surface0 fg:text"
+
+[os.symbols]
+Ubuntu = " "
+Linux = " "
+
+[username]
+show_always = false
+style_user = "bg:surface0 fg:text"
+style_root = "bg:surface0 fg:red"
+format = '[ $user]($style)'
+
+[directory]
+style = "fg:crust bg:peach"
+format = "[ $path ]($style)"
+truncation_length = 3
+truncation_symbol = "…/"
+
+[directory.substitutions]
+"Documents" = "󰈙 "
+"Downloads" = " "
+"Apps" = " "
+
+[git_branch]
+symbol = ""
+style = "bg:green"
+format = '[[ $symbol $branch ](fg:crust bg:green)]($style)'
+
+[git_status]
+style = "bg:green"
+format = '[[($all_status$ahead_behind )](fg:crust bg:green)]($style)'
+
+[nodejs]
+symbol = ""
+style = "bg:teal"
+format = '[[ $symbol ($version) ](fg:crust bg:teal)]($style)'
+
+[python]
+symbol = ""
+style = "bg:teal"
+format = '[[ $symbol ($version) ](fg:crust bg:teal)]($style)'
+
+[golang]
+symbol = ""
+style = "bg:teal"
+format = '[[ $symbol ($version) ](fg:crust bg:teal)]($style)'
+
+[rust]
+symbol = ""
+style = "bg:teal"
+format = '[[ $symbol ($version) ](fg:crust bg:teal)]($style)'
+
+[cmd_duration]
+min_time = 500
+style = "fg:text bg:surface0"
+format = '[  $duration ]($style)'
+
+[character]
+success_symbol = '[❯](bold green)'
+error_symbol = '[❯](bold red)'
+vimcmd_symbol = '[❮](bold green)'
+
+[palettes.catppuccin_mocha]
+rosewater = "#f5e0dc"
+flamingo = "#f2cdcd"
+pink = "#f5c2e7"
+mauve = "#cba6f7"
+red = "#f38ba8"
+maroon = "#eba0ac"
+peach = "#fab387"
+yellow = "#f9e2af"
+green = "#a6e3a1"
+teal = "#94e2d5"
+sky = "#89dceb"
+sapphire = "#74c7ec"
+blue = "#89b4fa"
+lavender = "#b4befe"
+text = "#cdd6f4"
+subtext1 = "#bac2de"
+subtext0 = "#a6adc8"
+overlay2 = "#9399b2"
+overlay1 = "#7f849c"
+overlay0 = "#6c7086"
+surface2 = "#585b70"
+surface1 = "#45475a"
+surface0 = "#313244"
+base = "#1e1e2e"
+mantle = "#181825"
+crust = "#11111b"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,13 +12,30 @@ SRC_GHOSTTY="$REPO_ROOT/configs/ghostty/config"
 SRC_TMUX="$REPO_ROOT/configs/tmux/tmux.conf"
 SRC_FONT_PICKER="$REPO_ROOT/scripts/font-picker.fish"
 SRC_DEV="$REPO_ROOT/scripts/dev.fish"
+SRC_FISH_CONFIG="$REPO_ROOT/configs/fish/config.fish"
+SRC_STARSHIP="$REPO_ROOT/configs/starship/starship.toml"
 
 GHOSTTY_DST="$HOME/.config/ghostty"
 TMUX_DST="$HOME/.config/tmux"
-FISH_FUNCS="$HOME/.config/fish/functions"
+FISH_DIR="$HOME/.config/fish"
+FISH_FUNCS="$FISH_DIR/functions"
+FISH_CONFIG_DST="$FISH_DIR/config.fish"
+STARSHIP_DST="$HOME/.config/starship.toml"
 
 FORCE=0
-[ "${1:-}" = "--force" ] && FORCE=1
+SETUP_SHELL=1
+for arg in "$@"; do
+    case "$arg" in
+        --force)    FORCE=1 ;;
+        --no-shell) SETUP_SHELL=0 ;;  # skip fish/starship/shell-env setup
+        *) echo "Unknown option: $arg (use --force and/or --no-shell)"; exit 2 ;;
+    esac
+done
+
+# Non-interactive if stdin is not a TTY (CI, piped, background agents): never
+# block on a prompt and never trigger an interactive sudo password request.
+NONINTERACTIVE=0
+[ -t 0 ] || NONINTERACTIVE=1
 
 mkdir -p "$GHOSTTY_DST" "$TMUX_DST" "$FISH_FUNCS"
 
@@ -51,6 +68,76 @@ echo "Linked font-picker -> $FISH_FUNCS/font-picker.fish"
 ln -sfn "$SRC_DEV" "$FISH_FUNCS/dev.fish"
 echo "Linked dev -> $FISH_FUNCS/dev.fish"
 
+# --- Fish shell environment (fish + starship + zoxide, config, default shell) -
+# Honors the repo's "fish primary, no zsh" standard. Idempotent. Tolerant of
+# missing sudo / non-interactive runs (warns instead of failing or hanging).
+setup_shell() {
+    # 1. System packages via apt (need sudo). Warn-don't-fail if unavailable.
+    local missing=()
+    command -v fish   >/dev/null 2>&1 || missing+=("fish")
+    command -v zoxide >/dev/null 2>&1 || missing+=("zoxide")
+    if [ "${#missing[@]}" -gt 0 ]; then
+        if [ "$NONINTERACTIVE" -eq 0 ] || sudo -n true 2>/dev/null; then
+            echo "Installing via apt: ${missing[*]}"
+            sudo apt-get update -qq || true
+            sudo apt-get install -y "${missing[@]}" \
+                || echo "WARNING: apt install failed - run: sudo apt install ${missing[*]}"
+        else
+            echo "WARNING: missing ${missing[*]} - run: sudo apt install ${missing[*]}"
+        fi
+    fi
+
+    # 2. Starship prompt (userspace install -> ~/.local/bin, no sudo).
+    if ! command -v starship >/dev/null 2>&1 && [ ! -x "$HOME/.local/bin/starship" ]; then
+        if command -v curl >/dev/null 2>&1; then
+            echo "Installing starship -> $HOME/.local/bin"
+            mkdir -p "$HOME/.local/bin"
+            curl -sS https://starship.rs/install.sh \
+                | sh -s -- --yes --bin-dir "$HOME/.local/bin" \
+                || echo "WARNING: starship install failed - see https://starship.rs"
+        else
+            echo "WARNING: curl not found - install starship manually: https://starship.rs"
+        fi
+    fi
+
+    # 3. Symlink shell configs so 'git pull' propagates updates.
+    ln -sfn "$SRC_FISH_CONFIG" "$FISH_CONFIG_DST"
+    echo "Linked fish config -> $FISH_CONFIG_DST"
+    ln -sfn "$SRC_STARSHIP" "$STARSHIP_DST"
+    echo "Linked starship config -> $STARSHIP_DST"
+
+    # 4. Make fish a valid login shell and offer to set it as default.
+    local fish_bin
+    fish_bin="$(command -v fish || true)"
+    if [ -z "$fish_bin" ]; then
+        echo "NOTE: fish not installed yet - install it, then re-run to set the default shell."
+        return
+    fi
+    if ! grep -qxF "$fish_bin" /etc/shells 2>/dev/null; then
+        echo "$fish_bin" | sudo tee -a /etc/shells >/dev/null 2>&1 \
+            && echo "Added $fish_bin to /etc/shells" \
+            || echo "NOTE: add $fish_bin to /etc/shells (needs sudo) before chsh."
+    fi
+    if [ "${SHELL:-}" != "$fish_bin" ]; then
+        if [ "$NONINTERACTIVE" -eq 0 ]; then
+            read -rp "Set fish as your default login shell now? [y/N] " ans
+            case "$ans" in
+                [Yy]*) chsh -s "$fish_bin" \
+                        && echo "Default shell set to fish (log out/in to apply)." \
+                        || echo "chsh failed - run it yourself: chsh -s $fish_bin" ;;
+                *) echo "Skipped. To switch later:  chsh -s $fish_bin" ;;
+            esac
+        else
+            echo "To make fish your default shell:  chsh -s $fish_bin"
+        fi
+    fi
+}
+if [ "$SETUP_SHELL" -eq 1 ]; then
+    setup_shell
+else
+    echo "Skipped fish/starship/shell-env setup (--no-shell)."
+fi
+
 # --- Check tmux is installed ---
 if ! command -v tmux >/dev/null 2>&1; then
     echo ""
@@ -72,9 +159,12 @@ cat <<'MSG'
 
 Next steps:
   1. Install tmux if not present:  sudo apt install tmux
-  2. Open Ghostty and run:  dev
+  2. If fish was just installed, set it as your default shell:  chsh -s $(command -v fish)
+     then log out/in. Start a new fish shell to load config.fish (starship prompt,
+     fnm/bun/uv/gum/glow completions, zoxide `z`, and ~/.mcp-secrets if present).
+  3. Open Ghostty and run:  dev
      -> toggles the og-tools tmux session: claude (claude/fish), codex, agy.
         Run `dev` again to detach, `dev` to reattach, `dev reset` to rebuild.
-  3. Run `font-picker` to change the Ghostty font (zenity list + live reload).
-  4. Reload Ghostty config: ctrl+shift+,  (or: pkill -SIGUSR2 ghostty)
+  4. Run `font-picker` to change the Ghostty font (zenity list + live reload).
+  5. Reload Ghostty config: ctrl+shift+,  (or: pkill -SIGUSR2 ghostty)
 MSG

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -9,6 +9,8 @@ DST_GHOSTTY="$HOME/.config/ghostty/config"
 DST_TMUX="$HOME/.config/tmux/tmux.conf"
 DST_FONT_PICKER="$HOME/.config/fish/functions/font-picker.fish"
 DST_DEV="$HOME/.config/fish/functions/dev.fish"
+DST_FISH_CONFIG="$HOME/.config/fish/config.fish"
+DST_STARSHIP="$HOME/.config/starship.toml"
 
 # Ghostty config: detect via managed-by marker or stale symlink
 if [ -f "$DST_GHOSTTY" ] && grep -q 'managed-by: ghostty-config-files' "$DST_GHOSTTY" 2>/dev/null; then
@@ -36,8 +38,8 @@ else
     echo "tmux config is not managed by this repo - skipping."
 fi
 
-# Fish function symlinks
-for dst in "$DST_FONT_PICKER" "$DST_DEV"; do
+# Fish function + shell config symlinks
+for dst in "$DST_FONT_PICKER" "$DST_DEV" "$DST_FISH_CONFIG" "$DST_STARSHIP"; do
     if [ -L "$dst" ] && [[ "$(readlink "$dst")" == "$REPO_ROOT"* ]]; then
         rm -f "$dst"
         echo "Removed $(basename "$dst") symlink $dst"
@@ -45,3 +47,8 @@ for dst in "$DST_FONT_PICKER" "$DST_DEV"; do
         echo "$(basename "$dst") is not managed by this repo - skipping."
     fi
 done
+
+# Note: apt packages (fish, zoxide), starship, and the chsh default-shell change
+# are intentionally NOT reverted here. To fully roll back the shell:
+#   chsh -s "$(command -v zsh || command -v bash)"   # restore previous login shell
+echo "Note: fish/zoxide/starship and your default shell (chsh) were left in place."


### PR DESCRIPTION
## What

Captures the full **fish-primary shell environment** in the repo so every machine reproduces it from one `install.sh`, aligning with the repo's declared standard (*"Shell: fish (primary), nushell (secondary). No zsh"*).

This machine (DGX Spark) was still on the old zsh + powerlevel10k setup; this PR is the reproducible replacement.

## Changes

- **`configs/fish/config.fish`** — fish interactive env: PATH (`~/.local/bin`, `~/.bun/bin`), `fnm --use-on-cd`, bun, uv/gum/glow completions, fzf, zoxide (`z`), starship init, and a parser for the machine-local bash-syntax `~/.mcp-secrets` (fish can't `source` bash `export`).
- **`configs/starship/starship.toml`** — Catppuccin Mocha prompt, replacing powerlevel10k (p10k config is zsh-only / not portable).
- **`scripts/install.sh`** — new `setup_shell` step: installs fish + zoxide (`sudo apt`) and starship (userspace `~/.local/bin`), symlinks `config.fish`/`starship.toml` into `~/.config` (so `git pull` propagates), and offers `chsh` to fish. Idempotent; tolerant of no-sudo / non-interactive runs (warns, never hangs). `--no-shell` skips it.
- **`scripts/uninstall.sh`** — removes the new symlinks (apt packages / starship / `chsh` intentionally left in place).
- **Docs** — README, AGENTS.md, CHANGELOG updated.

## Secrets

`~/.mcp-secrets` is **machine-local**, synced out-of-band, and **never committed**. `config.fish` only parses its `export` lines at startup.

## Validation

- `shellcheck scripts/install.sh scripts/uninstall.sh` — clean
- `ghostty +validate-config --config-file=configs/ghostty/config` — exit 0
- `config.fish` fish-syntax check + live shell verification done on the deploying machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)