### PR TITLE
feat(fish): apt-Section emoji tab-title engine (adversarially reviewed)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,9 +150,15 @@ pnpm-lock.yaml
 .env.test.local
 .env.production.local
 .envrc.local
+# direnv bootstrap is machine-local (sources .envrc.local); keep only the
+# tracked .envrc.local.example template. Never commit a real .envrc.
+.envrc
 
 # MCP Secrets (API keys - NEVER commit)
 .mcp-secrets
+# Per-machine tab-title label (e.g. "DGX") and any local Codacy token files
+.host-label
+.codacy/
 */.mcp-secrets
 
 # Vercel

--- a/.gitignore
+++ b/.gitignore
@@ -156,9 +156,6 @@ pnpm-lock.yaml
 
 # MCP Secrets (API keys - NEVER commit)
 .mcp-secrets
-# Per-machine tab-title label (e.g. "DGX") and any local Codacy token files
-.host-label
-.codacy/
 */.mcp-secrets
 
 # Vercel

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ This is a minimal Ghostty terminal config repo. Keep it simple.
 - `configs/tmux/tmux.conf` — minimal tmux config (window hint status bar, Mocha pane borders, mouse on)
 - `configs/fish/config.fish` — fish interactive env (PATH, fnm, bun, uv/gum/glow completions, fzf, zoxide, starship, mcp-secrets shim)
 - `configs/starship/starship.toml` — Catppuccin Mocha prompt (replaces the old powerlevel10k zsh prompt)
+- `configs/fish/functions/` — tab-title engine: `fish_title.fish` shows `🌐 <label> 📁 <path> <icon> <cmd>` (host shown only over SSH; `<label>` from machine-local `~/.host-label`, e.g. "DGX"). `__app_icon.fish` derives the per-command emoji from the command's apt `Section` (cached per session, small override list for non-apt tools); `__app_section_icon.fish` is the Section→emoji map. Single-codepoint emoji only (GTK tab labels can't render VS16/Nerd glyphs).
 - `scripts/font-picker.fish` — fish font picker function
 - `scripts/dev.fish` — fish function that toggles the `og-tools` tmux session (`claude`, `codex`, `agy`; rooted in `~/Apps/OG-tools`)
 - `scripts/install.sh` / `uninstall.sh` — deploy/remove scripts (install.sh also sets up the fish shell env; `--no-shell` skips that)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ ghostty +validate-config --config-file=configs/ghostty/config   # must exit 0
 shellcheck scripts/install.sh scripts/uninstall.sh
 ```
 
-shellcheck applies only to the `.sh` scripts; the `.fish` files (`config.fish`, `font-picker.fish`, `dev.fish`) are not shellcheck-compatible — sanity-check them with `fish --no-execute configs/fish/config.fish` instead.
+shellcheck applies only to the `.sh` scripts; the `.fish` files (`config.fish`, `font-picker.fish`, `dev.fish`, and `configs/fish/functions/*.fish`) are not shellcheck-compatible — sanity-check them with `fish --no-execute <file>` instead.
 
 ## User context
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Tab-title engine (`configs/fish/functions/`): `fish_title` shows `🌐 <label> 📁 <path> <icon> <cmd>` — host/label shown only over SSH (`<label>` from machine-local `~/.host-label`, e.g. "DGX", seeded from hostname by install.sh). The per-command emoji is derived **systematically from the command's apt `Section`** (`__app_icon` → `dpkg -S` → `${Section}` → `__app_section_icon`), cached per session with a small override list for non-apt tools; default `⚡`. Single-codepoint emoji only so GTK/AppKit tab labels render them. install.sh symlinks the functions; uninstall.sh removes them.
-- `.gitignore` now also excludes `.envrc` (machine-local direnv bootstrap), `.host-label`, and `.codacy/` so no machine-local config or token can be committed.
+- `.gitignore` now also excludes `.envrc` (machine-local direnv bootstrap that sources the gitignored `.envrc.local`) so it can't be committed by accident.
 - Fish shell environment captured in the repo for reproducible multi-machine setup: `configs/fish/config.fish` (PATH, fnm, bun, uv/gum/glow completions, fzf, zoxide `z`, starship, and a parser for the machine-local bash-syntax `~/.mcp-secrets`) and `configs/starship/starship.toml` (Catppuccin Mocha prompt, replacing the old powerlevel10k zsh setup).
 - `install.sh` now sets up the fish shell env: installs fish + zoxide (`sudo apt`) and starship (userspace `~/.local/bin`), symlinks `config.fish`/`starship.toml` into `~/.config`, and offers `chsh` to fish. Idempotent and tolerant of no-sudo / non-interactive runs. `--no-shell` skips it; `uninstall.sh` removes the new symlinks (apt/starship/chsh left in place).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Tab-title engine (`configs/fish/functions/`): `fish_title` shows `🌐 <label> 📁 <path> <icon> <cmd>` — host/label shown only over SSH (`<label>` from machine-local `~/.host-label`, e.g. "DGX", seeded from hostname by install.sh). The per-command emoji is derived **systematically from the command's apt `Section`** (`__app_icon` → `dpkg -S` → `${Section}` → `__app_section_icon`), cached per session with a small override list for non-apt tools; default `⚡`. Single-codepoint emoji only so GTK/AppKit tab labels render them. install.sh symlinks the functions; uninstall.sh removes them.
+- `.gitignore` now also excludes `.envrc` (machine-local direnv bootstrap), `.host-label`, and `.codacy/` so no machine-local config or token can be committed.
 - Fish shell environment captured in the repo for reproducible multi-machine setup: `configs/fish/config.fish` (PATH, fnm, bun, uv/gum/glow completions, fzf, zoxide `z`, starship, and a parser for the machine-local bash-syntax `~/.mcp-secrets`) and `configs/starship/starship.toml` (Catppuccin Mocha prompt, replacing the old powerlevel10k zsh setup).
 - `install.sh` now sets up the fish shell env: installs fish + zoxide (`sudo apt`) and starship (userspace `~/.local/bin`), symlinks `config.fish`/`starship.toml` into `~/.config`, and offers `chsh` to fish. Idempotent and tolerant of no-sudo / non-interactive runs. `--no-shell` skips it; `uninstall.sh` removes the new symlinks (apt/starship/chsh left in place).
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Uses tmux inside Ghostty for a scripted dev workspace.
 - `configs/tmux/tmux.conf` — minimal tmux config (window hint status bar, Mocha pane borders, mouse on)
 - `configs/fish/config.fish` — fish interactive env: PATH, fnm, bun, uv/gum/glow completions, fzf, zoxide (`z`), starship, and a `~/.mcp-secrets` parser
 - `configs/starship/starship.toml` — Catppuccin Mocha prompt (replaces powerlevel10k)
+- `configs/fish/functions/` — tab-title engine: `🌐 <label> 📁 <path> <icon> <cmd>` (host shown only over SSH; `<label>` from machine-local `~/.host-label`, e.g. `DGX`). The per-command emoji is derived from the command's apt `Section` (cached per session, small override list for non-apt tools)
 - `scripts/dev.fish` — fish function: `dev` toggles the `og-tools` tmux session (`claude`/`codex`/`agy`, rooted in `~/Apps/OG-tools`)
 - `scripts/font-picker.fish` — fish function to pick a Nerd Font via zenity with live reload
 - `scripts/install.sh` — deploys all configs, installs fish functions, and sets up the fish shell env (`--no-shell` skips the shell setup)

--- a/configs/fish/config.fish
+++ b/configs/fish/config.fish
@@ -54,8 +54,10 @@ if test -f "$HOME/.mcp-secrets"
     for line in (grep -E '^[[:space:]]*export[[:space:]]' "$HOME/.mcp-secrets")
         set -l kv (string replace -r '^[[:space:]]*export[[:space:]]+' '' -- $line)
         set -l parts (string split -m1 '=' -- $kv)
-        if test (count $parts) -eq 2
-            set -gx $parts[1] (string trim --chars=\"\' -- $parts[2])
+        # Only well-formed `NAME=value` with a valid shell identifier.
+        if test (count $parts) -eq 2; and string match -qr '^[A-Za-z_][A-Za-z0-9_]*$' -- $parts[1]
+            # Trim surrounding whitespace, then strip one layer of quotes.
+            set -gx $parts[1] (string trim -- $parts[2] | string trim --chars=\"\')
         end
     end
 end

--- a/configs/fish/functions/__app_icon.fish
+++ b/configs/fish/functions/__app_icon.fish
@@ -1,0 +1,81 @@
+function __app_icon --description 'Emoji for a command, derived from its apt Section (cached per session)'
+    # Resolve order: per-session cache -> apt Section -> non-apt override -> ⚡.
+    # The apt Section map (__app_section_icon) does the heavy lifting, so newly
+    # apt-installed tools get an icon automatically with no per-tool list to keep.
+    # All emoji are single-codepoint (render in GTK/AppKit tab labels).
+
+    # peel leading sudo/doas/wrappers and VAR=value assignments to reach the app
+    set -l words (string split ' ' -- (string trim -- $argv))
+    while set -q words[1]
+        switch $words[1]
+            case sudo doas command nice nohup time; set -e words[1]
+            case '*=*';                             set -e words[1]
+            case '*';                               break
+        end
+    end
+    set -q words[1]; or return
+    set -l c (string replace -r '.*/' '' -- $words[1])
+    test -n "$c"; or return
+
+    # --- per-session cache (linear scan; the command set per session is small) ---
+    for e in $__appicon_cache
+        set -l kv (string split -m1 '=' -- $e)
+        if test "$kv[1]" = "$c"
+            echo $kv[2]
+            return
+        end
+    end
+
+    set -l icon ''
+
+    # --- apt Section (only for real on-disk binaries; skips builtins/functions) ---
+    set -l bin (command -v $c 2>/dev/null)
+    if test -n "$bin"; and test -e "$bin"
+        set bin (realpath -- "$bin" 2>/dev/null; or echo $bin)
+        set -l owner (dpkg -S "$bin" 2>/dev/null | head -1)
+        if test -n "$owner"
+            # "pkg: path" or "pkg1, pkg2: path" (-m1 also drops any :arch on pkg)
+            set -l pkg (string trim -- (string split ',' -- (string split -m1 ':' -- $owner)[1])[1])
+            if test -n "$pkg"
+                set -l section (dpkg-query -W -f='${Section}' "$pkg" 2>/dev/null)
+                test -n "$section"; and set icon (__app_section_icon $section)
+            end
+        end
+    end
+
+    # --- non-apt overrides (AI/ML + tools installed outside apt) ---
+    if test -z "$icon"
+        switch $c
+            case claude claude-code;                set icon 🤖
+            case codex;                             set icon 🧠
+            case agy;                               set icon 👾
+            case gemini;                            set icon ✨
+            case ollama vllm llamacpp;              set icon 🦙
+            case hf huggingface-cli;                set icon 🤗
+            case comfyui comfy;                     set icon 🎨
+            case uv uvx;                            set icon 🐍
+            case bun;                               set icon 🥟
+            case deno;                              set icon 🦕
+            case node nodejs npm npx pnpm yarn fnm; set icon 📦
+            case cargo rustc rustup;                set icon 🦀
+            case go;                                set icon 🐹
+            case gh;                                set icon 🐙
+            case starship;                          set icon 🚀
+            case zoxide z;                          set icon 📂
+            case codacy codacy-cli codacy-cli-v2;   set icon ✅
+            case ghostty;                           set icon 👻
+            case nvidia-smi nvtop gpustat nvitop;   set icon 🎮
+            case aws gcloud az;                     set icon ⛅
+            case kubectl k9s helm;                  set icon 🚢
+        end
+    end
+
+    test -n "$icon"; or set icon ⚡
+
+    # --- cache the result (bounded to the most recent 256 commands) ---
+    set -g __appicon_cache $__appicon_cache "$c=$icon"
+    if test (count $__appicon_cache) -gt 256
+        set -g __appicon_cache $__appicon_cache[-256..-1]
+    end
+    echo $icon
+end

--- a/configs/fish/functions/__app_icon.fish
+++ b/configs/fish/functions/__app_icon.fish
@@ -1,19 +1,30 @@
 function __app_icon --description 'Emoji for a command, derived from its apt Section (cached per session)'
-    # Resolve order: per-session cache -> apt Section -> non-apt override -> ⚡.
-    # The apt Section map (__app_section_icon) does the heavy lifting, so newly
-    # apt-installed tools get an icon automatically with no per-tool list to keep.
-    # All emoji are single-codepoint (render in GTK/AppKit tab labels).
+    # Resolve order: per-session cache -> curated override -> apt Section -> ⚡.
+    # The override wins (curated icons beat generic Section icons and skip the
+    # dpkg cost); the apt Section map (__app_section_icon) auto-covers everything
+    # else with no per-tool list to maintain. Single-codepoint emoji only.
 
-    # peel leading sudo/doas/wrappers and VAR=value assignments to reach the app
     set -l words (string split ' ' -- (string trim -- $argv))
+    set -q words[1]; or return
+    set -l first $words[1]   # remember the leading token for the bare-wrapper case
+
+    # peel leading sudo/doas/wrappers and real NAME=value assignments
     while set -q words[1]
         switch $words[1]
-            case sudo doas command nice nohup time; set -e words[1]
-            case '*=*';                             set -e words[1]
-            case '*';                               break
+            case sudo doas command nice nohup time env
+                set -e words[1]
+            case '*=*'
+                # only a true `NAME=value` assignment (not e.g. /opt/a=b/tool)
+                if string match -qr '^[A-Za-z_][A-Za-z0-9_]*=' -- $words[1]
+                    set -e words[1]
+                else
+                    break
+                end
+            case '*'
+                break
         end
     end
-    set -q words[1]; or return
+    set -q words[1]; or set words $first   # bare wrapper -> icon the wrapper itself
     set -l c (string replace -r '.*/' '' -- $words[1])
     test -n "$c"; or return
 
@@ -28,45 +39,46 @@ function __app_icon --description 'Emoji for a command, derived from its apt Sec
 
     set -l icon ''
 
-    # --- apt Section (only for real on-disk binaries; skips builtins/functions) ---
-    set -l bin (command -v $c 2>/dev/null)
-    if test -n "$bin"; and test -e "$bin"
-        set bin (realpath -- "$bin" 2>/dev/null; or echo $bin)
-        set -l owner (dpkg -S "$bin" 2>/dev/null | head -1)
-        if test -n "$owner"
-            # "pkg: path" or "pkg1, pkg2: path" (-m1 also drops any :arch on pkg)
-            set -l pkg (string trim -- (string split ',' -- (string split -m1 ':' -- $owner)[1])[1])
-            if test -n "$pkg"
-                set -l section (dpkg-query -W -f='${Section}' "$pkg" 2>/dev/null)
-                test -n "$section"; and set icon (__app_section_icon $section)
-            end
-        end
+    # --- curated override (authoritative; also avoids the dpkg lookup) ---
+    switch $c
+        case nvim vim vi hx helix nano;         set icon 📝
+        case claude claude-code;                set icon 🤖
+        case codex;                             set icon 🧠
+        case agy;                               set icon 👾
+        case gemini;                            set icon ✨
+        case ollama vllm llamacpp;              set icon 🦙
+        case hf huggingface-cli;                set icon 🤗
+        case comfyui comfy;                     set icon 🎨
+        case uv uvx;                            set icon 🐍
+        case bun;                               set icon 🥟
+        case deno;                              set icon 🦕
+        case node nodejs npm npx pnpm yarn fnm; set icon 📦
+        case cargo rustc rustup;                set icon 🦀
+        case go;                                set icon 🐹
+        case gh;                                set icon 🐙
+        case starship;                          set icon 🚀
+        case zoxide z;                          set icon 📂
+        case codacy codacy-cli codacy-cli-v2;   set icon ✅
+        case ghostty;                           set icon 👻
+        case nvidia-smi nvtop gpustat nvitop;   set icon 🎮
+        case aws gcloud az;                     set icon ⛅
+        case kubectl k9s helm;                  set icon 🚢
     end
 
-    # --- non-apt overrides (AI/ML + tools installed outside apt) ---
+    # --- apt Section (only if no override matched; real on-disk binaries only) ---
     if test -z "$icon"
-        switch $c
-            case claude claude-code;                set icon 🤖
-            case codex;                             set icon 🧠
-            case agy;                               set icon 👾
-            case gemini;                            set icon ✨
-            case ollama vllm llamacpp;              set icon 🦙
-            case hf huggingface-cli;                set icon 🤗
-            case comfyui comfy;                     set icon 🎨
-            case uv uvx;                            set icon 🐍
-            case bun;                               set icon 🥟
-            case deno;                              set icon 🦕
-            case node nodejs npm npx pnpm yarn fnm; set icon 📦
-            case cargo rustc rustup;                set icon 🦀
-            case go;                                set icon 🐹
-            case gh;                                set icon 🐙
-            case starship;                          set icon 🚀
-            case zoxide z;                          set icon 📂
-            case codacy codacy-cli codacy-cli-v2;   set icon ✅
-            case ghostty;                           set icon 👻
-            case nvidia-smi nvtop gpustat nvitop;   set icon 🎮
-            case aws gcloud az;                     set icon ⛅
-            case kubectl k9s helm;                  set icon 🚢
+        set -l bin (command -v $c 2>/dev/null)
+        if test -n "$bin"; and test -e "$bin"
+            set bin (realpath -- "$bin" 2>/dev/null; or echo $bin)
+            set -l owner (dpkg -S "$bin" 2>/dev/null | head -1)
+            if test -n "$owner"
+                # "pkg: path" or "pkg1, pkg2: path" (-m1 also drops any :arch on pkg)
+                set -l pkg (string trim -- (string split ',' -- (string split -m1 ':' -- $owner)[1])[1])
+                if test -n "$pkg"
+                    set -l section (dpkg-query -W -f='${Section}' "$pkg" 2>/dev/null)
+                    test -n "$section"; and set icon (__app_section_icon $section)
+                end
+            end
         end
     end
 

--- a/configs/fish/functions/__app_section_icon.fish
+++ b/configs/fish/functions/__app_section_icon.fish
@@ -1,0 +1,47 @@
+function __app_section_icon --argument s --description 'Debian/apt Section -> single-codepoint emoji'
+    # The ONE map to maintain. Sections come from `dpkg-query -W -f='${Section}'`.
+    # Only Emoji_Presentation=Yes codepoints are used so they render as colour
+    # glyphs in a GTK/AppKit tab label WITHOUT a VS16 selector (VS16/Nerd glyphs
+    # can render as tofu there). Strip any "universe/"-style area prefix first.
+    set -l sec (string replace -r '.*/' '' -- $s)
+    switch $sec
+        case editors;                       echo 📝
+        case vcs;                           echo 🌿
+        case python;                        echo 🐍
+        case ruby;                          echo 💎
+        case perl;                          echo 🐪
+        case php;                           echo 🐘
+        case java;                          echo ☕
+        case javascript;                    echo 📦
+        case rust;                          echo 🦀
+        case haskell lisp ocaml;            echo 🧩
+        case interpreters;                  echo 📜
+        case devel libdevel;                echo 🔨
+        case admin;                         echo 🔧
+        case utils cli-mono misc;           echo 🧰
+        case shells;                        echo 🐚
+        case net comm;                      echo 📡
+        case web httpd;                     echo 🌐
+        case mail;                          echo 📧
+        case news;                          echo 📰
+        case database;                      echo 💽
+        case science;                       echo 🔬
+        case math gnu-r;                    echo 🧮
+        case electronics embedded hamradio; echo 🔌
+        case graphics;                      echo 🎨
+        case video;                         echo 🎬
+        case sound;                         echo 🔊
+        case text;                          echo 📄
+        case doc;                           echo 📖
+        case fonts;                         echo 🔤
+        case games;                         echo 🎲
+        case kernel;                        echo 🐧
+        case libs oldlibs;                  echo 📚
+        case localization;                  echo 🌍
+        case tex;                           echo 📐
+        case x11 gnome kde xfce;            echo 🪟
+        case otherosfs;                     echo 💾
+        case metapackages tasks;            echo 📦
+        case '*';                           echo ''   # unknown -> caller falls back
+    end
+end

--- a/configs/fish/functions/__app_section_icon.fish
+++ b/configs/fish/functions/__app_section_icon.fish
@@ -21,7 +21,7 @@ function __app_section_icon --argument s --description 'Debian/apt Section -> si
         case utils cli-mono misc;           echo 🧰
         case shells;                        echo 🐚
         case net comm;                      echo 📡
-        case web httpd;                     echo 🌐
+        case web httpd;                     echo 🧭
         case mail;                          echo 📧
         case news;                          echo 📰
         case database;                      echo 💽
@@ -41,7 +41,7 @@ function __app_section_icon --argument s --description 'Debian/apt Section -> si
         case tex;                           echo 📐
         case x11 gnome kde xfce;            echo 🪟
         case otherosfs;                     echo 💾
-        case metapackages tasks;            echo 📦
+        case metapackages tasks;            echo 🧱
         case '*';                           echo ''   # unknown -> caller falls back
     end
 end

--- a/configs/fish/functions/fish_title.fish
+++ b/configs/fish/functions/fish_title.fish
@@ -1,0 +1,29 @@
+function fish_title
+    # SSH-aware tab title:  🌐 <label>  📁 <path>  [<app-icon> <cmd>]
+    #   🌐 <label> : only over SSH; label from ~/.host-label (e.g. "DGX"), else short hostname
+    #   📁 <path>  : current directory, compact (~/A/g form)
+    #   <app-icon> : per-running-command emoji from __app_icon (apt-Section derived)
+    # `host` is an empty STRING (not an empty list) so local concatenation works.
+    set -l host ""
+    if set -q SSH_TTY
+        set -l label
+        test -r ~/.host-label; and set label (string trim < ~/.host-label)
+        test -z "$label"; and set label (prompt_hostname | string sub -l 12)
+        set host "🌐 $label "
+    end
+
+    set -l cmd
+    if set -q argv[1]
+        set cmd (string trim -- $argv[1])
+    else
+        set cmd (status current-command)
+        test "$cmd" = fish; and set cmd ""
+    end
+
+    if test -n "$cmd"
+        set -l icon (__app_icon $cmd)
+        echo -- $host"📁 "(prompt_pwd -d 1 -D 0)" $icon "(string sub -l 24 -- $cmd)
+    else
+        echo -- $host"📁 "(prompt_pwd -d 1 -D 0)
+    end
+end

--- a/configs/fish/functions/fish_title.fish
+++ b/configs/fish/functions/fish_title.fish
@@ -7,14 +7,16 @@ function fish_title
     set -l host ""
     if set -q SSH_TTY
         set -l label
-        test -r ~/.host-label; and set label (string trim < ~/.host-label)
+        # flatten any newlines and cap length, same as the hostname fallback
+        test -r ~/.host-label; and set label (string trim < ~/.host-label | string join ' ' | string sub -l 12)
         test -z "$label"; and set label (prompt_hostname | string sub -l 12)
         set host "🌐 $label "
     end
 
     set -l cmd
     if set -q argv[1]
-        set cmd (string trim -- $argv[1])
+        # collapse newlines so a multi-line command can't fan out into a list
+        set cmd (string trim -- $argv[1] | string collect | string replace -a -- \n ' ')
     else
         set cmd (status current-command)
         test "$cmd" = fish; and set cmd ""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,6 +12,7 @@ SRC_GHOSTTY="$REPO_ROOT/configs/ghostty/config"
 SRC_TMUX="$REPO_ROOT/configs/tmux/tmux.conf"
 SRC_FONT_PICKER="$REPO_ROOT/scripts/font-picker.fish"
 SRC_DEV="$REPO_ROOT/scripts/dev.fish"
+SRC_FISH_FUNCS_DIR="$REPO_ROOT/configs/fish/functions"
 SRC_FISH_CONFIG="$REPO_ROOT/configs/fish/config.fish"
 SRC_STARSHIP="$REPO_ROOT/configs/starship/starship.toml"
 
@@ -67,6 +68,20 @@ ln -sfn "$SRC_FONT_PICKER" "$FISH_FUNCS/font-picker.fish"
 echo "Linked font-picker -> $FISH_FUNCS/font-picker.fish"
 ln -sfn "$SRC_DEV" "$FISH_FUNCS/dev.fish"
 echo "Linked dev -> $FISH_FUNCS/dev.fish"
+
+# Tab-title engine: fish_title + apt-Section emoji resolver (__app_icon,
+# __app_section_icon). Symlinked so `git pull` propagates updates.
+for fn in fish_title __app_icon __app_section_icon; do
+    ln -sfn "$SRC_FISH_FUNCS_DIR/$fn.fish" "$FISH_FUNCS/$fn.fish"
+    echo "Linked $fn -> $FISH_FUNCS/$fn.fish"
+done
+
+# Friendly per-machine label for the SSH tab title (e.g. "DGX"). Seed it with the
+# short hostname if absent; edit ~/.host-label to taste. Never tracked by the repo.
+if [ ! -e "$HOME/.host-label" ]; then
+    hostname -s > "$HOME/.host-label" 2>/dev/null || hostname > "$HOME/.host-label"
+    echo "Seeded ~/.host-label -> $(cat "$HOME/.host-label" 2>/dev/null) (edit to taste)"
+fi
 
 # --- Fish shell environment (fish + starship + zoxide, config, default shell) -
 # Honors the repo's "fish primary, no zsh" standard. Idempotent. Tolerant of

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -78,9 +78,13 @@ done
 
 # Friendly per-machine label for the SSH tab title (e.g. "DGX"). Seed it with the
 # short hostname if absent; edit ~/.host-label to taste. Never tracked by the repo.
-if [ ! -e "$HOME/.host-label" ]; then
-    hostname -s > "$HOME/.host-label" 2>/dev/null || hostname > "$HOME/.host-label"
-    echo "Seeded ~/.host-label -> $(cat "$HOME/.host-label" 2>/dev/null) (edit to taste)"
+if [ ! -e "$HOME/.host-label" ] && [ ! -L "$HOME/.host-label" ]; then
+    _hl="$(hostname -s 2>/dev/null || hostname 2>/dev/null || echo localhost)"
+    if printf '%s\n' "$_hl" > "$HOME/.host-label" 2>/dev/null; then
+        echo "Seeded ~/.host-label -> $_hl (edit to taste)"
+    else
+        echo "NOTE: could not seed ~/.host-label - create it manually if desired."
+    fi
 fi
 
 # --- Fish shell environment (fish + starship + zoxide, config, default shell) -

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -38,8 +38,13 @@ else
     echo "tmux config is not managed by this repo - skipping."
 fi
 
+DST_FISH_TITLE="$HOME/.config/fish/functions/fish_title.fish"
+DST_APP_ICON="$HOME/.config/fish/functions/__app_icon.fish"
+DST_APP_SECTION_ICON="$HOME/.config/fish/functions/__app_section_icon.fish"
+
 # Fish function + shell config symlinks
-for dst in "$DST_FONT_PICKER" "$DST_DEV" "$DST_FISH_CONFIG" "$DST_STARSHIP"; do
+for dst in "$DST_FONT_PICKER" "$DST_DEV" "$DST_FISH_CONFIG" "$DST_STARSHIP" \
+           "$DST_FISH_TITLE" "$DST_APP_ICON" "$DST_APP_SECTION_ICON"; do
     if [ -L "$dst" ] && [[ "$(readlink "$dst")" == "$REPO_ROOT"* ]]; then
         rm -f "$dst"
         echo "Removed $(basename "$dst") symlink $dst"


### PR DESCRIPTION
## What

Adds a reproducible **tab-title engine** to the repo and hardens it via a multi-agent adversarial review.

`fish_title` renders `🌐 <label> 📁 <path> <icon> <cmd>`:
- host/label shown **only over SSH** (`<label>` from machine-local `~/.host-label`, e.g. `DGX`; seeded from hostname by install.sh; falls back to short hostname)
- per-command emoji derived **systematically from the command's apt `Section`** (`__app_icon` → `dpkg -S` → `${Section}` → `__app_section_icon`), **cached per session** (bounded 256), with a curated **override** for non-apt tools (claude/uv/node/cargo/gh/starship/codacy/ghostty/nvidia-smi/editors…) and `⚡` default
- **single-codepoint emoji only** (GTK/AppKit tab labels can't render VS16/Nerd glyphs)

install.sh symlinks the three functions (so `git pull` propagates) + seeds `~/.host-label`; uninstall.sh removes them.

## Adversarial review

6 Opus 4.8 reviewers (secrets, fish correctness, install idempotency, performance/caching, conventions, emoji-rendering) over the whole repo + diff, then a skeptic verify pass: **17 findings → 10 confirmed** (0 high, 2 medium, 8 low), **all applied**:
- override now precedes the dpkg lookup (curated icons win + skip ~130ms dpkg miss for listed tools)
- peel leading `env`; only peel real `NAME=value` (not paths with `=`); bare wrappers no longer yield an empty icon
- collapse newlines in the command; flatten + cap `~/.host-label`
- `install.sh` host-label seeding is non-fatal under `set -e` (dangling-symlink safe)
- `web/httpd` 🌐→🧭 (reserve 🌐 for SSH host); `metapackages` 📦→🧱
- dropped bogus `.gitignore` entries; added `.envrc`; docs updated

## Secret hygiene (pre-flight, per request)

Local secret scan + tracked-file check **clean** — no keys/tokens in any tracked file; `.envrc`, `.envrc.local`, `.mcp-secrets`, `~/.codacy/*`, `~/.host-label` are all un-committable. (Local Codacy CLI v2 + MCP server are installed on the DGX as the pre-flight scanner.)

## Validation

`shellcheck` clean · `fish --no-execute` on all `.fish` clean · `ghostty +validate-config` exit 0 · resolver functionally tested (apt-Section + override + cache, 134ms cold → 0.8ms cached).

🤖 Generated with [Claude Code](https://claude.com/claude-code)