### PR TITLE
chore(env): billing-token path, fish/starship tweaks, ignore tui binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,3 +225,6 @@ ghostty-installer
 # Download logs (wget artifacts)
 wget-log
 wget-log.*
+
+# Compiled TUI installer binary (build artifact)
+tui/installer

--- a/configs/fish/config.fish
+++ b/configs/fish/config.fish
@@ -61,3 +61,7 @@ if test -f "$HOME/.mcp-secrets"
         end
     end
 end
+
+
+# Added by Antigravity CLI installer
+set -gx PATH "/home/kkk/.local/bin" $PATH

--- a/configs/starship/starship.toml
+++ b/configs/starship/starship.toml
@@ -42,13 +42,14 @@ format = '[ $user]($style)'
 [directory]
 style = "fg:crust bg:peach"
 format = "[ $path ]($style)"
-truncation_length = 3
-truncation_symbol = "…/"
+truncation_length = 99
+truncation_symbol = ""
+truncate_to_repo = false
 
-[directory.substitutions]
-"Documents" = "󰈙 "
-"Downloads" = " "
-"Apps" = " "
+# [directory.substitutions]
+# "Documents" = "󰈙 "
+# "Downloads" = " "
+# "Apps" = " "
 
 [git_branch]
 symbol = ""


### PR DESCRIPTION
Fish config additions, starship prompt adjustments, and gitignore the compiled `tui/installer` build artifact (5.2MB ARM binary). Rebased onto latest main; the `.envrc.local.example` change was dropped since main intentionally trimmed that file to a minimal template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)