### PR TITLE
feat(fish): report cwd to Tabby via OSC 1337

### DIFF
--- a/configs/fish/config.fish
+++ b/configs/fish/config.fish
@@ -46,6 +46,15 @@ if type -q starship
     starship init fish | source
 end
 
+# --- Tabby working directory reporting -----------------------------------------
+# Tabby can't see cwd for remote/WSL/tmux/screen shells on its own, so report it
+# via OSC 1337 on every prompt (drives "same dir" new tabs, Copy current path,
+# and the SFTP panel). Harmless no-op in terminals that don't understand OSC 1337.
+# https://github.com/Eugeny/tabby/wiki/Shell-working-directory-reporting
+function __tabby_working_directory_reporting --on-event fish_prompt
+    echo -en "\e]1337;CurrentDir=$PWD\x7"
+end
+
 # --- MCP secrets --------------------------------------------------------------
 # ~/.mcp-secrets is bash syntax (`export KEY=VALUE`) and is synced between
 # machines out-of-band. It is NEVER committed to this repo. Fish cannot `source`


### PR DESCRIPTION
## Summary
- Adds a `fish_prompt`-triggered function that reports `$PWD` to Tabby via the OSC 1337 `CurrentDir` escape sequence.
- Fixes Tabby's "new tab defaults to home dir" / broken SFTP-panel-follows-cwd behavior for SSH/WSL/tmux/screen sessions, per https://github.com/Eugeny/tabby/wiki/Shell-working-directory-reporting
- No-op (ignored escape sequence) in terminals that don't understand OSC 1337.

## Test plan
- [ ] `source ~/.config/fish/config.fish` (or open a new fish tab) and confirm no errors
- [ ] In Tabby, open a new tab/split from a non-home directory and confirm it starts in the same directory
- [ ] Over SSH, confirm Tabby's SFTP panel follows the remote cwd

🤖 Generated with Claude Code