### PR TITLE
chore(env): remove Sakana AI token references

### DIFF
--- a/.envrc.local.example
+++ b/.envrc.local.example
@@ -8,7 +8,7 @@
 # Parent ~/Apps/.envrc.local (via source_up in .envrc) already loads shared
 # workspace tokens from ~/.dotfiles/: GH_*, HF_TOKEN/HUGGINGFACE_TOKEN,
 # CODACY_ACCOUNT_TOKEN, CODACY_API_TOKEN, CONTEXT7_API_KEY, DEEPSEEK_API_KEY,
-# SAKANA_API_KEY, PLAYWRIGHT_MCP_EXTENSION_TOKEN, and billing vars.
+# PLAYWRIGHT_MCP_EXTENSION_TOKEN and billing vars.
 #
 # Keep this file minimal: Codacy project token + org metadata for THIS repo only.
 


### PR DESCRIPTION
Removes all Sakana AI token references following account cancellation.

Sakana AI subscription cancelled and account closed; the keys are dead and were
revoked at the provider. This strips `SAKANA_API_KEY*` references from direnv
examples, docs, and orchestration scripts. Hermes/orchestration providers were
repointed to DeepSeek.

**Security note:** no Sakana token value was ever committed to any repo. Verified
by a full git-object scan across all 66 repos + 5 gists, including unreachable
objects and `refs/pull/*`. No history rewrite was required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVX97vfTaHamf6eRdC3D5u